### PR TITLE
[4.1] Fluent syntax example

### DIFF
--- a/app/Http/Controllers/Admin/FluentMonsterCrudController.php
+++ b/app/Http/Controllers/Admin/FluentMonsterCrudController.php
@@ -534,7 +534,7 @@ class FluentMonsterCrudController extends CrudController
         CRUD::filter('select_from_array')
                 ->type('dropdown')
                 ->label('Dropdown')
-                ->options(['one' => 'One', 'two' => 'Two', 'three' => 'Three'])
+                ->values(['one' => 'One', 'two' => 'Two', 'three' => 'Three'])
                 ->whenActive(function ($value) {
                     CRUD::addClause('where', 'select_from_array', $value);
                 })->apply();
@@ -578,7 +578,7 @@ class FluentMonsterCrudController extends CrudController
         CRUD::filter('select2')
                 ->type('select2')
                 ->label('Select2')
-                ->options(function () {
+                ->values(function () {
                     return \Backpack\NewsCRUD\app\Models\Category::all()->keyBy('id')->pluck('name', 'id')->toArray();
                 })->whenActive(function ($value) {
                     CRUD::addClause('where', 'select2', $value);
@@ -587,7 +587,7 @@ class FluentMonsterCrudController extends CrudController
         CRUD::filter('select2_multiple')
                 ->type('select2_multiple')
                 ->label('S2 multiple')
-                ->options(function () {
+                ->values(function () {
                     return \Backpack\NewsCRUD\app\Models\Category::all()->keyBy('id')->pluck('name', 'id')->toArray();
                 })->whenActive(function ($value) {
                     foreach (json_decode($values) as $key => $value) {
@@ -599,7 +599,7 @@ class FluentMonsterCrudController extends CrudController
                 ->type('select2_ajax')
                 ->label('S2 Ajax')
                 ->placeholder('Pick an article')
-                ->options(url('api/article-search'))
+                ->values(url('api/article-search'))
                 ->whenActive(function ($value) {
                     CRUD::addClause('where', 'select2_from_ajax', $value);
                 })->apply();

--- a/app/Http/Controllers/Admin/FluentMonsterCrudController.php
+++ b/app/Http/Controllers/Admin/FluentMonsterCrudController.php
@@ -3,10 +3,10 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Requests\MonsterRequest as StoreRequest;
-// VALIDATION: change the requests to match your own file names if you need form validation
 use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
 
-class MonsterCrudController extends CrudController
+class FluentMonsterCrudController extends CrudController
 {
     use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
@@ -17,9 +17,9 @@ class MonsterCrudController extends CrudController
 
     public function setup()
     {
-        $this->crud->setModel('App\Models\Monster');
-        $this->crud->setRoute(config('backpack.base.route_prefix').'/monster');
-        $this->crud->setEntityNameStrings('monster', 'monsters');
+        CRUD::setModel('App\Models\Monster');
+        CRUD::setRoute(config('backpack.base.route_prefix').'/fluent-monster');
+        CRUD::setEntityNameStrings('fluent monster', 'fluent monsters');
     }
 
     public function fetchProduct()
@@ -34,26 +34,15 @@ class MonsterCrudController extends CrudController
 
     public function setupListOperation()
     {
-        $this->crud->addColumns([
-            'text',
-            'textarea',
-            [
-                'name'  => 'image', // The db column name
-                'label' => 'Image', // Table column heading
-                'type'  => 'image',
-            ],
-            [
-                'name'  => 'base64_image', // The db column name
-                'label' => 'Base64 Image', // Table column heading
-                'type'  => 'image',
-            ],
-            [
-                'name'  => 'checkbox',
-                'label' => 'Boolean',
-                'type'  => 'boolean',
-                // optionally override the Yes/No texts
-                'options' => [0 => 'Yes', 1 => 'No'],
-                'wrapper' => [
+        CRUD::column('text');
+        CRUD::column('textarea');
+        CRUD::column('image')->type('image');
+        CRUD::column('base64_image')->type('image')->label('Base64 Image');
+        CRUD::column('checkbox')
+                ->type('boolean')
+                ->label('Boolean')
+                ->options([0 => 'Yes', 1 => 'No'])
+                ->wrapper([
                     'element' => 'span',
                     'class'   => function ($crud, $column, $entry, $related_key) {
                         if ($column['text'] == 'Yes') {
@@ -62,103 +51,59 @@ class MonsterCrudController extends CrudController
 
                         return 'badge badge-default';
                     },
-                ],
-            ],
-            [
-                'name'  => 'checkbox', // The db column name
-                'key'   => 'check',
-                'label' => 'Agreed', // Table column heading
-                'type'  => 'check',
-            ],
-            [
-                'name'     => 'created_at',
-                'label'    => 'Created At',
-                'type'     => 'closure',
-                'function' => function ($entry) {
+                ]);
+        CRUD::column('checkbox')->key('check')->label('Agreed')->type('check');
+        CRUD::column('created_at')->type('closure')->function(function ($entry) {
                     return 'Created on '.$entry->created_at;
-                },
-            ],
-            [
-                'name'  => 'name', // The db column name
-                'label' => 'Date', // Table column heading
-                'type'  => 'date',
-            ],
-            [
-                'name'  => 'name', // The db column name
-                'label' => 'Datetime', // Table column heading
-                'type'  => 'datetime',
-            ],
-            [
-                'name'  => 'email', // The db column name
-                'label' => 'Email Address', // Table column heading
-                'type'  => 'email',
-            ],
-            [
-                // show both text and email values in one column
-                // this column is here to demo and test the custom searchLogic functionality
-                'name'          => 'model_function',
-                'label'         => 'Text and Email', // Table column heading
-                'type'          => 'model_function',
-                'function_name' => 'getTextAndEmailAttribute', // the method in your Model
-                'searchLogic'   => function ($query, $column, $searchTerm) {
+                });
+        CRUD::column('date')->type('date');
+        CRUD::column('datetime')->type('datetime');
+        CRUD::column('email')->type('email')->label('Email Address');
+        // show both text and email values in one column
+        // this column is here to demo and test the custom searchLogic functionality
+        CRUD::column('model_function')
+                ->type('model_function')
+                ->label('Text and Email')
+                ->function_name('getTextAndEmailAttribute')
+                ->searchLogic(function ($query, $column, $searchTerm) {
                     $query->orWhere('email', 'like', '%'.$searchTerm.'%');
                     $query->orWhere('text', 'like', '%'.$searchTerm.'%');
-                },
-            ],
-            [
-                'name'  => 'number', // The db column name
-                'label' => 'Number', // Table column heading
-                'type'  => 'number',
-            ],
-            [
-                'name'        => 'radio',
-                'label'       => 'Radio',
-                'type'        => 'radio',
-                'options'     => [0 => 'Draft', 1 => 'Published', 2 => 'Other'],
-            ],
-            [   // 1-n relationship
-                'label'     => 'Select', // Table column heading
-                'type'      => 'select',
-                'name'      => 'select', // the column that contains the ID of that connected entity;
-                'entity'    => 'category', // the method that defines the relationship in your Model
-                'attribute' => 'name', // foreign key attribute that is shown to user
-                'model'     => "Backpack\NewsCRUD\app\Models\Category", // foreign key model
-                'wrapper'   => [
+                });
+        CRUD::column('number')->type('number');
+        CRUD::column('radio')
+                ->type('radio')
+                ->options([0 => 'Draft', 1 => 'Published', 2 => 'Other']);
+        CRUD::column('select')
+                ->type('select')
+                ->entity('category')
+                ->attribute('name')
+                ->model("Backpack\NewsCRUD\app\Models\Category")
+                ->wrapper([
                     'href' => function ($crud, $column, $entry, $related_key) {
                         return backpack_url('category/'.$related_key.'/show');
                     },
-                ],
-            ],
-            [   // select_from_array
-                'name'    => 'select_from_array',
-                'label'   => 'Select_from_array',
-                'type'    => 'select_from_array',
-                'options' => ['one' => 'One', 'two' => 'Two', 'three' => 'Three'],
-            ],
-            [   // select_multiple: n-n relationship (with pivot table)
-                'label'     => 'Select_multiple', // Table column heading
-                'type'      => 'select_multiple',
-                'name'      => 'tags', // the method that defines the relationship in your Model
-                'entity'    => 'tags', // the method that defines the relationship in your Model
-                'attribute' => 'name', // foreign key attribute that is shown to user
-                'model'     => "Backpack\NewsCRUD\app\Models\Tag", // foreign key model
-                'wrapper'   => [
+                ]);
+        CRUD::column('select_from_array')
+                ->type('select_from_array')
+                ->label('Select_from_array')
+                ->options(['one' => 'One', 'two' => 'Two', 'three' => 'Three']);
+        CRUD::column('tags')
+                ->type('select_multiple')
+                ->label('Select_multiple')
+                ->entity('tags')
+                ->attribute('name')
+                ->model('Backpack\NewsCRUD\app\Models\Tag')
+                ->wrapper([
                     'href' => function ($crud, $column, $entry, $related_key) {
                         return backpack_url('tag/'.$related_key.'/show');
                     },
-                ],
-            ],
-            [
-                'name'  => 'video', // The db column name
-                'label' => 'Video', // Table column heading
-                'type'  => 'video',
-            ],
-        ]);
+                ]);
+        CRUD::column('video')->type('video');
 
-        $this->crud->enableDetailsRow();
-        $this->crud->setDetailsRowView('vendor.backpack.crud.details_row.monster');
-        $this->crud->enableExportButtons();
-        $this->crud->addButtonFromModelFunction('line', 'open_google', 'openGoogle', 'beginning');
+        CRUD::enableDetailsRow();
+        CRUD::setDetailsRowView('vendor.backpack.crud.details_row.monster');
+        CRUD::enableExportButtons();
+        CRUD::addButtonFromModelFunction('line', 'open_google', 'openGoogle', 'beginning');
 
         $this->addCustomCrudFilters();
     }
@@ -166,195 +111,79 @@ class MonsterCrudController extends CrudController
     public function setupShowOperation()
     {
         $this->setupListOperation();
-        $this->crud->set('show.contentClass', 'col-md-12');
 
-        $this->crud->addColumn([   // SimpleMDE
-            'name'  => 'simplemde',
-            'label' => 'Markdown (SimpleMDE)',
-            'type'  => 'markdown',
-        ]);
+        CRUD::set('show.contentClass', 'col-md-12');
 
-        $this->crud->addColumn([
-            'name'            => 'table',
-            'label'           => 'Table',
-            'type'            => 'table',
-            'columns'         => [
-                'name'  => 'Name',
-                'desc'  => 'Description',
-                'price' => 'Price',
-            ],
-        ]);
-
-        $this->crud->addColumn([
-            'name'  => 'table', // The db column name
-            'key'   => 'table_count',
-            'label' => 'Array count', // Table column heading
-            'type'  => 'array_count',
-        ]);
-
-        $this->crud->addColumn([
-            'name'  => 'extras', // The db column name
-            'key'   => 'array',
-            'label' => 'Array', // Table column heading
-            'type'  => 'array',
-        ]);
-
-        $this->crud->addColumn([
-            'name'        => 'table', // The db column name
-            'key'         => 'multidimensional_array',
-            'label'       => 'Multidimensional Array', // Table column heading
-            'type'        => 'multidimensional_array',
-            'visible_key' => 'name',
-        ]);
-
-        $this->crud->addColumn([
-            'name'          => 'category',
-            'key'           => 'category_name',
-            'label'         => 'Model Function Attribute', // Table column heading
-            'type'          => 'model_function_attribute',
-            'function_name' => 'getCategory', // the method in your Model
-            'attribute'     => 'name',
-        ]);
-
-        $this->crud->addColumn([
-            'name'  => 'number', // The db column name
-            'key'   => 'phone',
-            'label' => 'Phone', // Table column heading
-            'type'  => 'phone',
-        ]);
-
-        $this->crud->addColumn([   // Upload
-            'name'   => 'upload_multiple',
-            'label'  => 'Upload Multiple',
-            'type'   => 'upload_multiple',
-            'prefix' => 'uploads/',
-        ]);
+        CRUD::column('simplemde')->type('markdown')->label('Markdown (SimpleMDE)');
+        CRUD::column('table')->type('table')->columns([
+                    'name'  => 'Name',
+                    'desc'  => 'Description',
+                    'price' => 'Price',
+                ]);
+        CRUD::column('name')->type('array_count')->key('table_count')->label('Array count');
+        CRUD::column('extras')->type('array')->key('array')->label('Array');
+        // CRUD::column('name')
+        //         ->type('multidimensional_array')
+        //         ->key('multidimensional_array')
+        //         ->visible_key('name');
+        CRUD::column('category')
+                ->label('Model Function Attribute')
+                ->type('model_function_attribute')
+                ->function_name('getCategory')
+                ->attribute('name');
+        CRUD::column('number')->type('phone')->label('Phone')->key('phone');
+        CRUD::column('upload_multiple')->type('upload_multiple')->prefix('uploads/');
     }
 
     protected function setupCreateOperation()
     {
-        $this->crud->setValidation(StoreRequest::class);
-        $this->crud->setOperationSetting('contentClass', 'col-md-12');
+        CRUD::setValidation(StoreRequest::class);
+        CRUD::setOperationSetting('contentClass', 'col-md-12');
 
-        $this->crud->addField([
-            'name'              => 'text',
-            'label'             => 'Text',
-            'type'              => 'text',
-            'tab'               => 'Simple',
-            'wrapperAttributes' => [
-                'class' => 'form-group col-md-6',
-            ],
-        ]);
+        CRUD::field('text')->type('text')->label('Text')
+            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-6', ]);
 
-        $this->crud->addField([
-            'name'              => 'email',
-            'label'             => 'Email',
-            'type'              => 'email',
-            'tab'               => 'Simple',
-            'wrapperAttributes' => [
-                'class' => 'form-group col-md-6',
-            ],
-        ]);
+        CRUD::field('email')->type('email')->label('Email')
+            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-6', ]);
 
-        $this->crud->addField([   // Textarea
-            'name'  => 'textarea',
-            'label' => 'Textarea',
-            'type'  => 'textarea',
-            'tab'   => 'Simple',
-        ]);
+        CRUD::field('textarea')->type('textarea')->label('Textarea')->tab('Simple');
+        CRUD::field('number')->type('number')->label('Number')
+            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-3', ]);
 
-        $this->crud->addField([   // Number
-            'name'  => 'number',
-            'label' => 'Number',
-            'type'  => 'number',
-            'tab'               => 'Simple',
-            'wrapperAttributes' => ['class' => 'form-group col-md-3'],
-        ]);
+        CRUD::field('float')->type('number')->label('Float')->attributes(['step' => 'any'])
+            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-3', ]);
 
-        $this->crud->addField([   // Number
-            'name'  => 'float',
-            'label' => 'Float',
-            'type'  => 'number',
-            'attributes' => ['step' => 'any'], // allow decimals
-            'tab'               => 'Simple',
-            'wrapperAttributes' => ['class' => 'form-group col-md-3'],
-        ]);
+        CRUD::field('number_with_prefix')->type('number')
+            ->prefix('$')->fake(true)->store_in('extras')
+            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-3', ]);
 
-        $this->crud->addField([   // Number
-            'name'  => 'number_with_prefix',
-            'label' => 'Number with prefix',
-            'type'  => 'number',
-            'prefix' => '$',
-            'fake'              => true,
-            'store_in'          => 'extras',
-            'tab'               => 'Simple',
-            'wrapperAttributes' => ['class' => 'form-group col-md-3'],
-        ]);
+        CRUD::field('number_with_suffix')->type('number')
+            ->suffix('.00')->fake(true)->store_in('extras')
+            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-3', ]);
 
-        $this->crud->addField([   // Number
-            'name'  => 'number_with_suffix',
-            'label' => 'Number with suffix',
-            'type'  => 'number',
-            'suffix'            => '.00',
-            'fake'              => true,
-            'store_in'          => 'extras',
-            'tab'               => 'Simple',
-            'wrapperAttributes' => ['class' => 'form-group col-md-3'],
-        ]);
+        CRUD::field('text_with_both_prefix_and_suffix')->type('number')
+            ->prefix('@')->suffix("<i class='la la-home'></i>")->fake(true)->store_in('extras')
+            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-6', ]);
 
-        $this->crud->addField([   // Number
-            'name'              => 'text_with_both_prefix_and_suffix',
-            'label'             => 'Text with both prefix and suffix',
-            'type'              => 'number',
-            'prefix'            => '@',
-            'suffix'            => "<i class='fa fa-home'></i>",
-            'fake'              => true,
-            'store_in'          => 'extras',
-            'tab'               => 'Simple',
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-        ]);
+        CRUD::field('password')->type('password')
+            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-6', ]);
 
-        $this->crud->addField([   // Password
-            'name'              => 'password',
-            'label'             => 'Password',
-            'type'              => 'password',
-            'tab'               => 'Simple',
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-        ]);
-
-        $this->crud->addField([
-            'name'    => 'radio', // the name of the db column
-            'label'   => 'Status (radio)', // the input label
-            'type'    => 'radio',
-            'options' => [ // the key will be stored in the db, the value will be shown as label;
+        CRUD::field('radio')->type('radio')->label('Status (radio)')->options([ 
+                // the key will be stored in the db, the value will be shown as label;
                 0 => 'Draft',
                 1 => 'Published',
                 2 => 'Other',
-            ],
-            // optional
-            'inline' => true, // show the radios all on the same line?
-            'tab'    => 'Simple',
-        ]);
+            ])->inline(true)->tab('Simple');
 
-        $this->crud->addField([   // Checkbox
-            'name'  => 'checkbox',
-            'label' => 'I have not read the terms and conditions and I never will (checkbox)',
-            'type'  => 'checkbox',
-            'tab'   => 'Simple',
-        ]);
+        CRUD::field('checkbox')->type('checkbox')->label('I have not read the termins and conditions and I never will (checkbox)')->tab('Simple');
 
-        $this->crud->addField([   // Hidden
-            'name'    => 'hidden',
-            'type'    => 'hidden',
-            'default' => 'hidden value',
-            'tab'     => 'Simple',
-        ]);
+        CRUD::field('hidden')->type('hidden')->default('hidden value')->tab('Simple');
 
         // -----------------
         // DATE, TIME AND SPACE tab
         // -----------------
 
-        $this->crud->addField([   // Month
+        CRUD::addField([   // Month
             'name'              => 'week',
             'label'             => 'Week',
             'type'              => 'week',
@@ -362,7 +191,7 @@ class MonsterCrudController extends CrudController
             'tab'               => 'Time and space',
         ]);
 
-        $this->crud->addField([   // Month
+        CRUD::addField([   // Month
             'name'              => 'month',
             'label'             => 'Month',
             'type'              => 'month',
@@ -370,7 +199,7 @@ class MonsterCrudController extends CrudController
             'tab'               => 'Time and space',
         ]);
 
-        $this->crud->addField([   // Date
+        CRUD::addField([   // Date
             'name'       => 'date',
             'label'      => 'Date (HTML5 spec)',
             'type'       => 'date',
@@ -382,7 +211,7 @@ class MonsterCrudController extends CrudController
             'tab'               => 'Time and space',
         ]);
 
-        $this->crud->addField([   // Date
+        CRUD::addField([   // Date
             'name'  => 'date_picker',
             'label' => 'Date (jQuery plugin)',
             'type'  => 'date_picker',
@@ -396,7 +225,7 @@ class MonsterCrudController extends CrudController
             'tab'               => 'Time and space',
         ]);
 
-        $this->crud->addField([   // DateTime
+        CRUD::addField([   // DateTime
             'name'              => 'datetime',
             'label'             => 'Datetime (HTML5 spec)',
             'type'              => 'datetime',
@@ -404,7 +233,7 @@ class MonsterCrudController extends CrudController
             'tab'               => 'Time and space',
         ]);
 
-        $this->crud->addField([   // DateTime
+        CRUD::addField([   // DateTime
             'name'  => 'datetime_picker',
             'label' => 'Datetime picker (jQuery plugin)',
             'type'  => 'datetime_picker',
@@ -417,7 +246,7 @@ class MonsterCrudController extends CrudController
             'tab'               => 'Time and space',
         ]);
 
-        $this->crud->addField([ // Date_range
+        CRUD::addField([ // Date_range
             'name'       => ['start_date', 'end_date'], // a unique name for this field
             'label'      => 'Date Range',
             'type'       => 'date_range',
@@ -430,7 +259,7 @@ class MonsterCrudController extends CrudController
             'tab' => 'Time and space',
         ]);
 
-        $this->crud->addField([   // Address
+        CRUD::addField([   // Address
             'name'  => 'address',
             'label' => 'Address (Algolia Places search)',
             'type'  => 'address',
@@ -443,14 +272,14 @@ class MonsterCrudController extends CrudController
         // SELECTS tab
         // -----------------
 
-        $this->crud->addField([   // CustomHTML
+        CRUD::addField([   // CustomHTML
             'name'  => 'select_1_n_heading',
             'type'  => 'custom_html',
             'value' => '<h5 class="mb-0 text-primary">1-n Relationships (HasOne, BelongsTo)</h5>',
             'tab'   => 'Selects',
         ]);
 
-        $this->crud->addField([    // SELECT
+        CRUD::addField([    // SELECT
             'label'     => 'Select (HTML Spec Select Input for 1-n relationship)',
             'type'      => 'select',
             'name'      => 'select',
@@ -460,7 +289,7 @@ class MonsterCrudController extends CrudController
             'tab'       => 'Selects',
         ]);
 
-        $this->crud->addField([    // SELECT2
+        CRUD::addField([    // SELECT2
             'label'             => 'Select2 (1-n relationship)',
             'type'              => 'select2',
             'name'              => 'select2',
@@ -471,7 +300,7 @@ class MonsterCrudController extends CrudController
             'wrapperAttributes' => ['class' => 'form-group col-md-6'],
         ]);
 
-        $this->crud->addField([ // select2_from_ajax: 1-n relationship
+        CRUD::addField([ // select2_from_ajax: 1-n relationship
             'label'                => "Article <small class='font-light'>(select2_from_ajax for a 1-n relationship)</small>", // Table column heading
             'type'                 => 'select2_from_ajax',
             'name'                 => 'select2_from_ajax', // the column that contains the ID of that connected entity;
@@ -485,7 +314,7 @@ class MonsterCrudController extends CrudController
             'wrapperAttributes'    => ['class' => 'form-group col-md-6'],
         ]);
 
-        $this->crud->addField([    // Relationship
+        CRUD::addField([    // Relationship
             'label'     => 'Relationship (1-n with InlineCreate; no AJAX) <span class="badge badge-warning">New in 4.1</span>',
             'type'      => 'relationship',
             'name'      => 'icon_id',
@@ -497,14 +326,14 @@ class MonsterCrudController extends CrudController
             'wrapperAttributes' => ['class' => 'form-group col-md-6'],
         ]);
 
-        $this->crud->addField([   // CustomHTML
+        CRUD::addField([   // CustomHTML
             'name'  => 'select_n_n_heading',
             'type'  => 'custom_html',
             'value' => '<h5 class="mb-0 mt-3 text-primary">n-n Relationship with Pivot Table (HasMany, BelongsToMany)</h5>',
             'tab'   => 'Selects',
         ]);
 
-        $this->crud->addField([       // Select_Multiple = n-n relationship
+        CRUD::addField([       // Select_Multiple = n-n relationship
             'label'     => 'Select_multiple (n-n relationship with pivot table)',
             'type'      => 'select_multiple',
             'name'      => 'tags', // the method that defines the relationship in your Model
@@ -515,7 +344,7 @@ class MonsterCrudController extends CrudController
             'tab'       => 'Selects',
         ]);
 
-        $this->crud->addField([       // Select2Multiple = n-n relationship (with pivot table)
+        CRUD::addField([       // Select2Multiple = n-n relationship (with pivot table)
             'label'             => 'Select2_multiple (n-n relationship with pivot table)',
             'type'              => 'select2_multiple',
             'name'              => 'categories', // the method that defines the relationship in your Model
@@ -528,7 +357,7 @@ class MonsterCrudController extends CrudController
             'wrapperAttributes' => ['class' => 'form-group col-md-6'],
         ]);
 
-        $this->crud->addField([ // Select2_from_ajax_multiple: n-n relationship with pivot table
+        CRUD::addField([ // Select2_from_ajax_multiple: n-n relationship with pivot table
             'label'                => "Articles <small class='font-light'>(select2_from_ajax_multiple for an n-n relationship with pivot table)</small>", // Table column heading
             'type'                 => 'select2_from_ajax_multiple',
             'name'                 => 'articles', // the column that contains the ID of that connected entity;
@@ -543,7 +372,7 @@ class MonsterCrudController extends CrudController
             'wrapperAttributes'    => ['class' => 'form-group col-md-6'],
         ]);
 
-        $this->crud->addField([    // Relationship
+        CRUD::addField([    // Relationship
             'label'     => 'Relationship (n-n with InlineCreate; Fetch using AJAX) <span class="badge badge-warning">New in 4.1</span>',
             'type'      => 'relationship',
             'name'      => 'products',
@@ -557,14 +386,14 @@ class MonsterCrudController extends CrudController
             'wrapperAttributes' => ['class' => 'form-group col-md-6'],
         ]);
 
-        $this->crud->addField([   // CustomHTML
+        CRUD::addField([   // CustomHTML
             'name'  => 'select_heading',
             'type'  => 'custom_html',
             'value' => '<h5 class="mb-0 mt-3 text-primary">No Relationship</h5>',
             'tab'   => 'Selects',
         ]);
 
-        $this->crud->addField([ // select_from_array
+        CRUD::addField([ // select_from_array
             'name'              => 'select_from_array',
             'label'             => 'Select_from_array (no relationship, 1-1 or 1-n)',
             'type'              => 'select_from_array',
@@ -575,7 +404,7 @@ class MonsterCrudController extends CrudController
             'wrapperAttributes' => ['class' => 'form-group col-md-6'],
         ]);
 
-        $this->crud->addField([ // select2_from_array
+        CRUD::addField([ // select2_from_array
             'name'              => 'select2_from_array',
             'label'             => 'Select2_from_array (no relationship, 1-1 or 1-n)',
             'type'              => 'select2_from_array',
@@ -586,7 +415,7 @@ class MonsterCrudController extends CrudController
             'wrapperAttributes' => ['class' => 'form-group col-md-6'],
         ]);
 
-        $this->crud->addField([ // select_and_order
+        CRUD::addField([ // select_and_order
             'name'    => 'select_and_order',
             'label'   => 'Select_and_order',
             'type'    => 'select_and_order',
@@ -610,7 +439,7 @@ class MonsterCrudController extends CrudController
         // -----------------
 
         if (app('env') == 'production') {
-            $this->crud->addField([   // CustomHTML
+            CRUD::addField([   // CustomHTML
                 'name'      => 'separator',
                 'type'      => 'custom_html',
                 'value'     => '<p><small><strong>Note: </strong>In the online demo we\'ve restricted the upload and media library fields a lot, or hidden them entirely. To test them out, you can <a target="_blank" href="https://backpackforlaravel.com/docs/demo">download and install this demo admin panel</a> in your local environment.</small></p>',
@@ -618,14 +447,14 @@ class MonsterCrudController extends CrudController
             ]);
         }
 
-        $this->crud->addField([   // Browse
+        CRUD::addField([   // Browse
             'name'  => 'browse',
             'label' => 'Browse (using elFinder)',
             'type'  => 'browse',
             'tab'   => 'Uploads',
         ]);
 
-        $this->crud->addField([   // Browse multiple
+        CRUD::addField([   // Browse multiple
             'name'     => 'browse_multiple',
             'label'    => 'Browse multiple',
             'type'     => 'browse_multiple',
@@ -635,7 +464,7 @@ class MonsterCrudController extends CrudController
             // 'mime_types' => null, // visible mime prefixes; ex. ['image'] or ['application/pdf']
         ]);
 
-        $this->crud->addField([   // Upload
+        CRUD::addField([   // Upload
             'name'   => 'upload',
             'label'  => 'Upload',
             'type'   => 'upload',
@@ -646,7 +475,7 @@ class MonsterCrudController extends CrudController
             'tab' => 'Uploads',
         ]);
 
-        $this->crud->addField([   // Upload
+        CRUD::addField([   // Upload
             'name'   => 'upload_multiple',
             'label'  => 'Upload Multiple',
             'type'   => 'upload_multiple',
@@ -657,7 +486,7 @@ class MonsterCrudController extends CrudController
             'tab' => 'Uploads',
         ]);
 
-        $this->crud->addField([ // base64_image
+        CRUD::addField([ // base64_image
             'label'        => 'Base64 Image - includes cropping',
             'name'         => 'base64_image',
             'filename'     => null, // set to null if not needed
@@ -668,7 +497,7 @@ class MonsterCrudController extends CrudController
             'tab'          => 'Uploads',
         ]);
 
-        $this->crud->addField([ // image
+        CRUD::addField([ // image
             'label'        => 'Image - includes cropping',
             'name'         => 'image',
             'type'         => 'image',
@@ -683,28 +512,28 @@ class MonsterCrudController extends CrudController
         // -----------------
         // BIG TEXTS tab
         // -----------------
-        $this->crud->addField([   // SimpleMDE
+        CRUD::addField([   // SimpleMDE
             'name'  => 'simplemde',
             'label' => 'SimpleMDE - markdown editor',
             'type'  => 'simplemde',
             'tab'   => 'Big texts',
         ]);
 
-        $this->crud->addField([   // Summernote
+        CRUD::addField([   // Summernote
             'name'  => 'summernote',
             'label' => 'Summernote editor',
             'type'  => 'summernote',
             'tab'   => 'Big texts',
         ]);
 
-        $this->crud->addField([   // CKEditor
+        CRUD::addField([   // CKEditor
             'name'  => 'wysiwyg',
             'label' => 'CKEditor - also called the WYSIWYG field',
             'type'  => 'ckeditor',
             'tab'   => 'Big texts',
         ]);
 
-        $this->crud->addField([   // TinyMCE
+        CRUD::addField([   // TinyMCE
             'name'  => 'tinymce',
             'label' => 'TinyMCE',
             'type'  => 'tinymce',
@@ -714,7 +543,7 @@ class MonsterCrudController extends CrudController
         // -----------------
         // MISCELLANEOUS tab
         // -----------------
-        $this->crud->addField([   // Color
+        CRUD::addField([   // Color
             'name'  => 'color',
             'label' => 'Color picker (HTML5 spec)',
             'type'  => 'color',
@@ -722,7 +551,7 @@ class MonsterCrudController extends CrudController
             'tab'               => 'Miscellaneous',
             'wrapperAttributes' => ['class' => 'form-group col-md-6'],
         ]);
-        $this->crud->addField([   // Color
+        CRUD::addField([   // Color
             'name'  => 'color_picker',
             'label' => 'Color picker (jQuery plugin)',
             'type'  => 'color_picker',
@@ -731,7 +560,7 @@ class MonsterCrudController extends CrudController
             'wrapperAttributes' => ['class' => 'form-group col-md-6'],
         ]);
 
-        $this->crud->addField([
+        CRUD::addField([
             'label'   => 'Icon Picker',
             'name'    => 'icon_picker',
             'type'    => 'icon_picker',
@@ -739,7 +568,7 @@ class MonsterCrudController extends CrudController
             'tab'     => 'Miscellaneous',
         ]);
 
-        $this->crud->addField([ // Table
+        CRUD::addField([ // Table
             'name'            => 'table',
             'label'           => 'Table',
             'type'            => 'table',
@@ -754,7 +583,7 @@ class MonsterCrudController extends CrudController
             'tab' => 'Miscellaneous',
         ]);
 
-        $this->crud->addField([ // Table
+        CRUD::addField([ // Table
             'name'            => 'fake_table',
             'label'           => 'Fake Table',
             'type'            => 'table',
@@ -772,7 +601,7 @@ class MonsterCrudController extends CrudController
 
         // $table->string('url')->nullable;
         // $table->text('video')->nullable;
-        $this->crud->addField([   // URL
+        CRUD::addField([   // URL
             'name'  => 'video',
             'label' => 'Video - link to video file on Youtube or Vimeo',
             'type'  => 'video',
@@ -780,7 +609,7 @@ class MonsterCrudController extends CrudController
         ]);
         // $table->string('range')->nullable;
 
-        // $this->crud->removeField('name', 'update/create/both');
+        // CRUD::removeField('name', 'update/create/both');
     }
 
     protected function setupUpdateOperation()
@@ -790,122 +619,84 @@ class MonsterCrudController extends CrudController
 
     public function addCustomCrudFilters()
     {
-        $this->crud->addFilter(
-            [ // add a "simple" filter called Draft
-                'type'  => 'simple',
-                'name'  => 'checkbox',
-                'label' => 'Simple',
-            ],
-            false, // the simple filter has no values, just the "Draft" label specified above
-        function () { // if the filter is active (the GET parameter "draft" exits)
-            $this->crud->addClause('where', 'checkbox', '1');
-        }
-        );
+        CRUD::filter('checkbox')
+                ->type('simple')
+                ->label('Simple')
+                ->whenActive(function() {
+                    CRUD::addClause('where', 'checkbox', '1');
+                })->apply();
 
-        $this->crud->addFilter([ // dropdown filter
-            'name' => 'select_from_array',
-            'type' => 'dropdown',
-            'label'=> 'Dropdown',
-        ], ['one' => 'One', 'two' => 'Two', 'three' => 'Three'], function ($value) {
-            // if the filter is active
-            $this->crud->addClause('where', 'select_from_array', $value);
-        });
+        CRUD::filter('select_from_array')
+                ->type('dropdown')
+                ->label('Dropdown')
+                ->options(['one' => 'One', 'two' => 'Two', 'three' => 'Three'])
+                ->whenActive(function($value) {
+                    CRUD::addClause('where', 'select_from_array', $value);
+                })->apply();
 
-        $this->crud->addFilter(
-            [ // text filter
-                'type'  => 'text',
-                'name'  => 'text',
-                'label' => 'Text',
-            ],
-            false,
-            function ($value) { // if the filter is active
-                $this->crud->addClause('where', 'text', 'LIKE', "%$value%");
-            }
-        );
+        CRUD::filter('text')
+                ->type('text')
+                ->label('Text')
+                ->whenActive(function($value) {
+                    CRUD::addClause('where', 'text', 'LIKE', "%$value%");
+                })->apply();
 
-        $this->crud->addFilter(
-            [
-                'name'       => 'number',
-                'type'       => 'range',
-                'label'      => 'Range',
-                'label_from' => 'min value',
-                'label_to'   => 'max value',
-            ],
-            false,
-            function ($value) { // if the filter is active
-                $range = json_decode($value);
-                if ($range->from && $range->to) {
-                    $this->crud->addClause('where', 'number', '>=', (float) $range->from);
-                    $this->crud->addClause('where', 'number', '<=', (float) $range->to);
-                }
-            }
-        );
+        CRUD::filter('number')
+                ->type('range')
+                ->label('Range')
+                ->label_from('min value')
+                ->label_to('max value')
+                ->whenActive(function($value) {
+                    $range = json_decode($value);
+                    if ($range->from && $range->to) {
+                        CRUD::addClause('where', 'number', '>=', (float) $range->from);
+                        CRUD::addClause('where', 'number', '<=', (float) $range->to);
+                    }
+                })->apply();
 
-        $this->crud->addFilter(
-            [ // date filter
-                'type'  => 'date',
-                'name'  => 'date',
-                'label' => 'Date',
-            ],
-            false,
-            function ($value) { // if the filter is active, apply these constraints
-                $this->crud->addClause('where', 'date', '=', $value);
-            }
-        );
+        CRUD::filter('date')
+                ->type('date')
+                ->label('Date')
+                ->whenActive(function($value) {
+                    CRUD::addClause('where', 'date', '=', $value);
+                })->apply();
 
-        $this->crud->addFilter(
-            [ // daterange filter
-                'type' => 'date_range',
-                'name' => 'date_range',
-                'label'=> 'Date range',
-                // 'date_range_options' => [
-                // 'format' => 'YYYY/MM/DD',
-                // 'locale' => ['format' => 'YYYY/MM/DD'],
-                // 'showDropdowns' => true,
-                // 'showWeekNumbers' => true
-                // ]
-            ],
-            false,
-            function ($value) { // if the filter is active, apply these constraints
-                $dates = json_decode($value);
-                $this->crud->addClause('where', 'date', '>=', $dates->from);
-                $this->crud->addClause('where', 'date', '<=', $dates->to);
-            }
-        );
+        CRUD::filter('date_range')
+                ->type('date_range')
+                ->label('Date range')
+                ->whenActive(function($value) {
+                    $dates = json_decode($value);
+                    CRUD::addClause('where', 'date', '>=', $dates->from);
+                    CRUD::addClause('where', 'date', '<=', $dates->to);
+                })->apply();
 
-        $this->crud->addFilter([ // select2 filter
-            'name' => 'select2',
-            'type' => 'select2',
-            'label'=> 'Select2',
-        ], function () {
-            return \Backpack\NewsCRUD\app\Models\Category::all()->keyBy('id')->pluck('name', 'id')->toArray();
-        }, function ($value) { // if the filter is active
-            $this->crud->addClause('where', 'select2', $value);
-        });
+        CRUD::filter('select2')
+                ->type('select2')
+                ->label('Select2')
+                ->options(function() {
+                    return \Backpack\NewsCRUD\app\Models\Category::all()->keyBy('id')->pluck('name', 'id')->toArray();
+                })->whenActive(function($value) {
+                    CRUD::addClause('where', 'select2', $value);
+                })->apply();
 
-        $this->crud->addFilter([ // select2_multiple filter
-            'name' => 'select2_multiple',
-            'type' => 'select2_multiple',
-            'label'=> 'S2 multiple',
-        ], function () {
-            return \Backpack\NewsCRUD\app\Models\Category::all()->keyBy('id')->pluck('name', 'id')->toArray();
-        }, function ($values) { // if the filter is active
-            foreach (json_decode($values) as $key => $value) {
-                $this->crud->addClause('orWhere', 'select2', $value);
-            }
-        });
+        CRUD::filter('select2_multiple')
+                ->type('select2_multiple')
+                ->label('S2 multiple')
+                ->options(function() {
+                    return \Backpack\NewsCRUD\app\Models\Category::all()->keyBy('id')->pluck('name', 'id')->toArray();
+                })->whenActive(function($value) {
+                    foreach (json_decode($values) as $key => $value) {
+                        CRUD::addClause('orWhere', 'select2', $value);
+                    }
+                })->apply();
 
-        $this->crud->addFilter(
-            [ // select2_ajax filter
-                'name'        => 'select2_from_ajax',
-                'type'        => 'select2_ajax',
-                'label'       => 'S2 Ajax',
-                'placeholder' => 'Pick an article',
-            ],
-            url('api/article-search'), // the ajax route
-        function ($value) { // if the filter is active
-            $this->crud->addClause('where', 'select2_from_ajax', $value);
-        }
-        );
+        CRUD::filter('select2_from_ajax')
+                ->type('select2_ajax')
+                ->label('S2 Ajax')
+                ->placeholder('Pick an article')
+                ->options(url('api/article-search'))
+                ->whenActive(function($value) {
+                    CRUD::addClause('where', 'select2_from_ajax', $value);
+                })->apply();
     }
 }

--- a/app/Http/Controllers/Admin/FluentMonsterCrudController.php
+++ b/app/Http/Controllers/Admin/FluentMonsterCrudController.php
@@ -185,13 +185,12 @@ class FluentMonsterCrudController extends CrudController
 
         CRUD::field('week')
             ->type('week')
-            ->wrapperAttributes([ 'class' => 'form-group col-md-6', ])
+            ->wrapperAttributes(['class' => 'form-group col-md-6'])
             ->tab('Time and space');
-
 
         CRUD::field('month')
             ->type('month')
-            ->wrapperAttributes([ 'class' => 'form-group col-md-6', ])
+            ->wrapperAttributes(['class' => 'form-group col-md-6'])
             ->tab('Time and space');
 
         CRUD::field('date')
@@ -201,7 +200,7 @@ class FluentMonsterCrudController extends CrudController
                 'pattern'     => '[0-9]{4}-[0-9]{2}-[0-9]{2}',
                 'placeholder' => 'yyyy-mm-dd',
             ])
-            ->wrapperAttributes([ 'class' => 'form-group col-md-6', ])
+            ->wrapperAttributes(['class' => 'form-group col-md-6'])
             ->tab('Time and space');
 
         CRUD::field('date_picker')

--- a/app/Http/Controllers/Admin/FluentMonsterCrudController.php
+++ b/app/Http/Controllers/Admin/FluentMonsterCrudController.php
@@ -54,8 +54,8 @@ class FluentMonsterCrudController extends CrudController
                 ]);
         CRUD::column('checkbox')->key('check')->label('Agreed')->type('check');
         CRUD::column('created_at')->type('closure')->function(function ($entry) {
-                    return 'Created on '.$entry->created_at;
-                });
+            return 'Created on '.$entry->created_at;
+        });
         CRUD::column('date')->type('date');
         CRUD::column('datetime')->type('datetime');
         CRUD::column('email')->type('email')->label('Email Address');
@@ -116,10 +116,10 @@ class FluentMonsterCrudController extends CrudController
 
         CRUD::column('simplemde')->type('markdown')->label('Markdown (SimpleMDE)');
         CRUD::column('table')->type('table')->columns([
-                    'name'  => 'Name',
-                    'desc'  => 'Description',
-                    'price' => 'Price',
-                ]);
+            'name'  => 'Name',
+            'desc'  => 'Description',
+            'price' => 'Price',
+        ]);
         CRUD::column('name')->type('array_count')->key('table_count')->label('Array count');
         CRUD::column('extras')->type('array')->key('array')->label('Array');
         // CRUD::column('name')
@@ -141,39 +141,39 @@ class FluentMonsterCrudController extends CrudController
         CRUD::setOperationSetting('contentClass', 'col-md-12');
 
         CRUD::field('text')->type('text')->label('Text')
-            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-6', ]);
+            ->tab('Simple')->wrapperAttributes(['class' => 'form-group col-md-6']);
 
         CRUD::field('email')->type('email')->label('Email')
-            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-6', ]);
+            ->tab('Simple')->wrapperAttributes(['class' => 'form-group col-md-6']);
 
         CRUD::field('textarea')->type('textarea')->label('Textarea')->tab('Simple');
         CRUD::field('number')->type('number')->label('Number')
-            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-3', ]);
+            ->tab('Simple')->wrapperAttributes(['class' => 'form-group col-md-3']);
 
         CRUD::field('float')->type('number')->label('Float')->attributes(['step' => 'any'])
-            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-3', ]);
+            ->tab('Simple')->wrapperAttributes(['class' => 'form-group col-md-3']);
 
         CRUD::field('number_with_prefix')->type('number')
             ->prefix('$')->fake(true)->store_in('extras')
-            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-3', ]);
+            ->tab('Simple')->wrapperAttributes(['class' => 'form-group col-md-3']);
 
         CRUD::field('number_with_suffix')->type('number')
             ->suffix('.00')->fake(true)->store_in('extras')
-            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-3', ]);
+            ->tab('Simple')->wrapperAttributes(['class' => 'form-group col-md-3']);
 
         CRUD::field('text_with_both_prefix_and_suffix')->type('number')
             ->prefix('@')->suffix("<i class='la la-home'></i>")->fake(true)->store_in('extras')
-            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-6', ]);
+            ->tab('Simple')->wrapperAttributes(['class' => 'form-group col-md-6']);
 
         CRUD::field('password')->type('password')
-            ->tab('Simple')->wrapperAttributes([ 'class' => 'form-group col-md-6', ]);
+            ->tab('Simple')->wrapperAttributes(['class' => 'form-group col-md-6']);
 
-        CRUD::field('radio')->type('radio')->label('Status (radio)')->options([ 
-                // the key will be stored in the db, the value will be shown as label;
-                0 => 'Draft',
-                1 => 'Published',
-                2 => 'Other',
-            ])->inline(true)->tab('Simple');
+        CRUD::field('radio')->type('radio')->label('Status (radio)')->options([
+            // the key will be stored in the db, the value will be shown as label;
+            0 => 'Draft',
+            1 => 'Published',
+            2 => 'Other',
+        ])->inline(true)->tab('Simple');
 
         CRUD::field('checkbox')->type('checkbox')->label('I have not read the termins and conditions and I never will (checkbox)')->tab('Simple');
 
@@ -527,7 +527,7 @@ class FluentMonsterCrudController extends CrudController
         CRUD::filter('checkbox')
                 ->type('simple')
                 ->label('Simple')
-                ->whenActive(function() {
+                ->whenActive(function () {
                     CRUD::addClause('where', 'checkbox', '1');
                 })->apply();
 
@@ -535,14 +535,14 @@ class FluentMonsterCrudController extends CrudController
                 ->type('dropdown')
                 ->label('Dropdown')
                 ->options(['one' => 'One', 'two' => 'Two', 'three' => 'Three'])
-                ->whenActive(function($value) {
+                ->whenActive(function ($value) {
                     CRUD::addClause('where', 'select_from_array', $value);
                 })->apply();
 
         CRUD::filter('text')
                 ->type('text')
                 ->label('Text')
-                ->whenActive(function($value) {
+                ->whenActive(function ($value) {
                     CRUD::addClause('where', 'text', 'LIKE', "%$value%");
                 })->apply();
 
@@ -551,7 +551,7 @@ class FluentMonsterCrudController extends CrudController
                 ->label('Range')
                 ->label_from('min value')
                 ->label_to('max value')
-                ->whenActive(function($value) {
+                ->whenActive(function ($value) {
                     $range = json_decode($value);
                     if ($range->from && $range->to) {
                         CRUD::addClause('where', 'number', '>=', (float) $range->from);
@@ -562,14 +562,14 @@ class FluentMonsterCrudController extends CrudController
         CRUD::filter('date')
                 ->type('date')
                 ->label('Date')
-                ->whenActive(function($value) {
+                ->whenActive(function ($value) {
                     CRUD::addClause('where', 'date', '=', $value);
                 })->apply();
 
         CRUD::filter('date_range')
                 ->type('date_range')
                 ->label('Date range')
-                ->whenActive(function($value) {
+                ->whenActive(function ($value) {
                     $dates = json_decode($value);
                     CRUD::addClause('where', 'date', '>=', $dates->from);
                     CRUD::addClause('where', 'date', '<=', $dates->to);
@@ -578,18 +578,18 @@ class FluentMonsterCrudController extends CrudController
         CRUD::filter('select2')
                 ->type('select2')
                 ->label('Select2')
-                ->options(function() {
+                ->options(function () {
                     return \Backpack\NewsCRUD\app\Models\Category::all()->keyBy('id')->pluck('name', 'id')->toArray();
-                })->whenActive(function($value) {
+                })->whenActive(function ($value) {
                     CRUD::addClause('where', 'select2', $value);
                 })->apply();
 
         CRUD::filter('select2_multiple')
                 ->type('select2_multiple')
                 ->label('S2 multiple')
-                ->options(function() {
+                ->options(function () {
                     return \Backpack\NewsCRUD\app\Models\Category::all()->keyBy('id')->pluck('name', 'id')->toArray();
-                })->whenActive(function($value) {
+                })->whenActive(function ($value) {
                     foreach (json_decode($values) as $key => $value) {
                         CRUD::addClause('orWhere', 'select2', $value);
                     }
@@ -600,7 +600,7 @@ class FluentMonsterCrudController extends CrudController
                 ->label('S2 Ajax')
                 ->placeholder('Pick an article')
                 ->options(url('api/article-search'))
-                ->whenActive(function($value) {
+                ->whenActive(function ($value) {
                     CRUD::addClause('where', 'select2_from_ajax', $value);
                 })->apply();
     }

--- a/app/Http/Controllers/Admin/FluentMonsterCrudController.php
+++ b/app/Http/Controllers/Admin/FluentMonsterCrudController.php
@@ -183,433 +183,338 @@ class FluentMonsterCrudController extends CrudController
         // DATE, TIME AND SPACE tab
         // -----------------
 
-        CRUD::addField([   // Month
-            'name'              => 'week',
-            'label'             => 'Week',
-            'type'              => 'week',
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-            'tab'               => 'Time and space',
-        ]);
+        CRUD::field('week')
+            ->type('week')
+            ->wrapperAttributes([ 'class' => 'form-group col-md-6', ])
+            ->tab('Time and space');
 
-        CRUD::addField([   // Month
-            'name'              => 'month',
-            'label'             => 'Month',
-            'type'              => 'month',
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-            'tab'               => 'Time and space',
-        ]);
 
-        CRUD::addField([   // Date
-            'name'       => 'date',
-            'label'      => 'Date (HTML5 spec)',
-            'type'       => 'date',
-            'attributes' => [
+        CRUD::field('month')
+            ->type('month')
+            ->wrapperAttributes([ 'class' => 'form-group col-md-6', ])
+            ->tab('Time and space');
+
+        CRUD::field('date')
+            ->type('date')
+            ->label('Date (HTML5 spec)')
+            ->attributes([
                 'pattern'     => '[0-9]{4}-[0-9]{2}-[0-9]{2}',
                 'placeholder' => 'yyyy-mm-dd',
-            ],
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-            'tab'               => 'Time and space',
-        ]);
+            ])
+            ->wrapperAttributes([ 'class' => 'form-group col-md-6', ])
+            ->tab('Time and space');
 
-        CRUD::addField([   // Date
-            'name'  => 'date_picker',
-            'label' => 'Date (jQuery plugin)',
-            'type'  => 'date_picker',
-            // optional:
-            'date_picker_options' => [
+        CRUD::field('date_picker')
+            ->type('date_picker')
+            ->label('Date (jQuery plugin)')
+            ->date_picker_options([
                 'todayBtn' => true,
                 'format'   => 'dd-mm-yyyy',
                 'language' => 'en',
-            ],
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-            'tab'               => 'Time and space',
-        ]);
+            ])
+            ->wrapperAttributes(['class' => 'form-group col-md-6'])
+            ->tab('Time and space');
 
-        CRUD::addField([   // DateTime
-            'name'              => 'datetime',
-            'label'             => 'Datetime (HTML5 spec)',
-            'type'              => 'datetime',
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-            'tab'               => 'Time and space',
-        ]);
+        CRUD::field('datetime')
+            ->type('datetime')
+            ->label('Datetime (HTML5 spec)')
+            ->wrapperAttributes(['class' => 'form-group col-md-6'])
+            ->tab('Time and space');
 
-        CRUD::addField([   // DateTime
-            'name'  => 'datetime_picker',
-            'label' => 'Datetime picker (jQuery plugin)',
-            'type'  => 'datetime_picker',
-            // optional:
-            'datetime_picker_options' => [
+        CRUD::field('datetime_picker')
+            ->type('datetime_picker')
+            ->label('Datetime picker (jQuery plugin)')
+            ->datetime_picker_options([
                 'format'   => 'DD/MM/YYYY HH:mm',
                 'language' => 'en',
-            ],
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-            'tab'               => 'Time and space',
-        ]);
+            ])
+            ->wrapperAttributes(['class' => 'form-group col-md-6'])
+            ->tab('Time and space');
 
-        CRUD::addField([ // Date_range
-            'name'       => ['start_date', 'end_date'], // a unique name for this field
-            'label'      => 'Date Range',
-            'type'       => 'date_range',
-            'default'    => ['2020-03-28 01:01', '2020-04-05 02:00'],
-            // OPTIONALS
-            'date_range_options' => [ // options sent to daterangepicker.js
-                'timePicker' => true,
-                'locale'     => ['format' => 'DD/MM/YYYY HH:mm'],
-            ],
-            'tab' => 'Time and space',
-        ]);
+        // CRUD::field(['start_date', 'end_date'])
+        //     ->type('date_range')
+        //     ->label('Date Range')
+        //     ->default(['2020-03-28 01:01', '2020-04-05 02:00'])
+        //     ->date_range_options([
+        //         'timePicker' => true,
+        //         'locale'     => ['format' => 'DD/MM/YYYY HH:mm'],
+        //     ])
+        //     ->tab('Time and space');
 
-        CRUD::addField([   // Address
-            'name'  => 'address',
-            'label' => 'Address (Algolia Places search)',
-            'type'  => 'address',
-            // optional
-            'store_as_json' => true,
-            'tab'           => 'Time and space',
-        ]); // the second parameter for the addField method is the form it should place this field in; specify either 'create', 'update' or 'both'; default is 'both', so you might aswell not mention it;
+        CRUD::field('address')
+            ->type('address')
+            ->label('Address (Algolia Places search)')
+            ->store_as_json(true)
+            ->tab('Time and space');
 
         // -----------------
         // SELECTS tab
         // -----------------
 
-        CRUD::addField([   // CustomHTML
-            'name'  => 'select_1_n_heading',
-            'type'  => 'custom_html',
-            'value' => '<h5 class="mb-0 text-primary">1-n Relationships (HasOne, BelongsTo)</h5>',
-            'tab'   => 'Selects',
-        ]);
+        CRUD::field('select_1_n_heading')->type('custom_html')->tab('Selects')
+                ->value('<h5 class="mb-0 text-primary">1-n Relationships (HasOne, BelongsTo)</h5>');
 
-        CRUD::addField([    // SELECT
-            'label'     => 'Select (HTML Spec Select Input for 1-n relationship)',
-            'type'      => 'select',
-            'name'      => 'select',
-            'entity'    => 'category',
-            'attribute' => 'name',
-            'model'     => "Backpack\NewsCRUD\app\Models\Category",
-            'tab'       => 'Selects',
-        ]);
+        CRUD::field('select')
+                ->type('select')
+                ->label('Select (HTML Spec Select Input for 1-n relationship)')
+                ->entity('category')
+                ->attribute('name')
+                ->model('Backpack\NewsCRUD\app\Models\Category')
+                ->wrapperAttributes(['class' => 'form-group col-md-6'])
+                ->tab('Selects');
 
-        CRUD::addField([    // SELECT2
-            'label'             => 'Select2 (1-n relationship)',
-            'type'              => 'select2',
-            'name'              => 'select2',
-            'entity'            => 'category',
-            'attribute'         => 'name',
-            'model'             => "Backpack\NewsCRUD\app\Models\Category",
-            'tab'               => 'Selects',
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-        ]);
+        CRUD::field('select2')
+                ->type('select2')
+                ->label('Select2 (1-n relationship)')
+                ->entity('category')
+                ->attribute('name')
+                ->model('Backpack\NewsCRUD\app\Models\Category')
+                ->wrapperAttributes(['class' => 'form-group col-md-6'])
+                ->tab('Selects');
 
-        CRUD::addField([ // select2_from_ajax: 1-n relationship
-            'label'                => "Article <small class='font-light'>(select2_from_ajax for a 1-n relationship)</small>", // Table column heading
-            'type'                 => 'select2_from_ajax',
-            'name'                 => 'select2_from_ajax', // the column that contains the ID of that connected entity;
-            'entity'               => 'article', // the method that defines the relationship in your Model
-            'attribute'            => 'title', // foreign key attribute that is shown to user
-            'model'                => "Backpack\NewsCRUD\app\Models\Article", // foreign key model
-            'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
-            'placeholder'          => 'Select an article', // placeholder for the select
-            'minimum_input_length' => 2, // minimum characters to type before querying results
-            'tab'                  => 'Selects',
-            'wrapperAttributes'    => ['class' => 'form-group col-md-6'],
-        ]);
+        CRUD::field('select2_from_ajax')
+                ->type('select2_from_ajax')
+                ->label("Article <small class='font-light'>(select2_from_ajax for a 1-n relationship)</small>")
+                ->entity('article')
+                ->attribute('title')
+                ->model('Backpack\NewsCRUD\app\Models\Article')
+                ->data_source(url('api/article'))
+                ->placeholder('Select an article')
+                ->minimum_input_length(2)
+                ->wrapperAttributes(['class' => 'form-group col-md-6'])
+                ->tab('Selects');
 
-        CRUD::addField([    // Relationship
-            'label'     => 'Relationship (1-n with InlineCreate; no AJAX) <span class="badge badge-warning">New in 4.1</span>',
-            'type'      => 'relationship',
-            'name'      => 'icon_id',
-            // 'entity'    => 'icon',
-            'attribute' => 'name',
-            // 'tab'       => 'Selects',
-            'inline_create' => true, // TODO: make this work
-            // 'data_source' => backpack_url('monster/fetch/icon'),
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-        ]);
+        CRUD::field('icon_id')
+                ->type('relationship')
+                ->label('Relationship (1-n with InlineCreate; no AJAX) <span class="badge badge-warning">New in 4.1</span>')
+                // ->entity('icon')
+                ->attribute('name')
+                // ->data_source(backpack_url('monster/fetch/icon'))
+                ->inline_create(true)
+                ->wrapperAttributes(['class' => 'form-group col-md-6'])
+                ->tab('Selects');
 
-        CRUD::addField([   // CustomHTML
-            'name'  => 'select_n_n_heading',
-            'type'  => 'custom_html',
-            'value' => '<h5 class="mb-0 mt-3 text-primary">n-n Relationship with Pivot Table (HasMany, BelongsToMany)</h5>',
-            'tab'   => 'Selects',
-        ]);
+        CRUD::field('select_n_n_heading')->type('custom_html')->tab('Selects')
+            ->value('<h5 class="mb-0 mt-3 text-primary">n-n Relationship with Pivot Table (HasMany, BelongsToMany)</h5>');
 
-        CRUD::addField([       // Select_Multiple = n-n relationship
-            'label'     => 'Select_multiple (n-n relationship with pivot table)',
-            'type'      => 'select_multiple',
-            'name'      => 'tags', // the method that defines the relationship in your Model
-            'entity'    => 'tags', // the method that defines the relationship in your Model
-            'attribute' => 'name', // foreign key attribute that is shown to user
-            'model'     => "Backpack\NewsCRUD\app\Models\Tag", // foreign key model
-            'pivot'     => true, // on create&update, do you need to add/delete pivot table entries?
-            'tab'       => 'Selects',
-        ]);
+        CRUD::field('tags')
+                ->type('select_multiple')
+                ->label('Select_multiple (n-n relationship with pivot table)')
+                ->entity('tags')
+                ->attribute('name')
+                ->model('Backpack\NewsCRUD\app\Models\Tag')
+                ->pivot(true)
+                ->tab('Selects');
 
-        CRUD::addField([       // Select2Multiple = n-n relationship (with pivot table)
-            'label'             => 'Select2_multiple (n-n relationship with pivot table)',
-            'type'              => 'select2_multiple',
-            'name'              => 'categories', // the method that defines the relationship in your Model
-            'entity'            => 'categories', // the method that defines the relationship in your Model
-            'attribute'         => 'name', // foreign key attribute that is shown to user
-            'model'             => "Backpack\NewsCRUD\app\Models\Category", // foreign key model
-            'allows_null'       => true,
-            'pivot'             => true, // on create&update, do you need to add/delete pivot table entries?
-            'tab'               => 'Selects',
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-        ]);
+        CRUD::field('categories')
+                ->type('select2_multiple')
+                ->label('Select2_multiple (n-n relationship with pivot table)')
+                ->entity('categories')
+                ->attribute('name')
+                ->model(\Backpack\NewsCRUD\app\Models\Category::class)
+                ->allows_null(true)
+                ->pivot(true)
+                ->wrapperAttributes(['class' => 'form-group col-md-6'])
+                ->tab('Selects');
 
-        CRUD::addField([ // Select2_from_ajax_multiple: n-n relationship with pivot table
-            'label'                => "Articles <small class='font-light'>(select2_from_ajax_multiple for an n-n relationship with pivot table)</small>", // Table column heading
-            'type'                 => 'select2_from_ajax_multiple',
-            'name'                 => 'articles', // the column that contains the ID of that connected entity;
-            'entity'               => 'articles', // the method that defines the relationship in your Model
-            'attribute'            => 'title', // foreign key attribute that is shown to user
-            'model'                => "Backpack\NewsCRUD\app\Models\Article", // foreign key model
-            'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
-            'placeholder'          => 'Select one or more articles', // placeholder for the select
-            'minimum_input_length' => 2, // minimum characters to type before querying results
-            'pivot'                => true, // on create&update, do you need to add/delete pivot table entries?
-            'tab'                  => 'Selects',
-            'wrapperAttributes'    => ['class' => 'form-group col-md-6'],
-        ]);
+        CRUD::field('articles')
+                ->type('select2_from_ajax_multiple')
+                ->label("Articles <small class='font-light'>(select2_from_ajax_multiple for an n-n relationship with pivot table)</small>")
+                ->entity('articles')
+                ->attribute('title')
+                ->model(\Backpack\NewsCRUD\app\Models\Article::class)
+                ->data_source(url('api/article'))
+                ->placeholder('Select one or more articles')
+                ->minimum_input_length(2)
+                ->pivot(true)
+                ->wrapperAttributes(['class' => 'form-group col-md-6'])
+                ->tab('Selects');
 
-        CRUD::addField([    // Relationship
-            'label'     => 'Relationship (n-n with InlineCreate; Fetch using AJAX) <span class="badge badge-warning">New in 4.1</span>',
-            'type'      => 'relationship',
-            'name'      => 'products',
-            'entity'    => 'products',
-            // 'attribute' => 'name',
-            // 'tab'       => 'Selects',
-            'ajax' => true,
-            // 'inline_create' => true, // TODO: make it work like this too
-            'inline_create'     => ['entity' => 'product'],
-            'data_source'       => backpack_url('monster/fetch/product'),
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-        ]);
+        CRUD::field('products')
+                ->type('relationship')
+                ->label('Relationship (n-n with InlineCreate; Fetch using AJAX) <span class="badge badge-warning">New in 4.1</span>')
+                ->entity('products')
+                // ->attribute('name')
+                ->ajax(true)
+                ->data_source(backpack_url('monster/fetch/product'))
+                // ->inline_create(true) // TODO: make it work this way too
+                ->inline_create(['entity' => 'product'])
+                // ->wrapperAttributes(['class' => 'form-group col-md-6'])
+                ->tab('Selects');
 
-        CRUD::addField([   // CustomHTML
-            'name'  => 'select_heading',
-            'type'  => 'custom_html',
-            'value' => '<h5 class="mb-0 mt-3 text-primary">No Relationship</h5>',
-            'tab'   => 'Selects',
-        ]);
+        CRUD::field('select_heading')->type('custom_html')->tab('Selects')
+            ->value('<h5 class="mb-0 mt-3 text-primary">No Relationship</h5>');
 
-        CRUD::addField([ // select_from_array
-            'name'              => 'select_from_array',
-            'label'             => 'Select_from_array (no relationship, 1-1 or 1-n)',
-            'type'              => 'select_from_array',
-            'options'           => ['one' => 'One', 'two' => 'Two', 'three' => 'Three'],
-            'allows_null'       => true,
-            'tab'               => 'Selects',
-            'allows_multiple'   => false, // OPTIONAL; needs you to cast this to array in your model;
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-        ]);
+        CRUD::field('select_from_array')
+                ->type('select_from_array')
+                ->label('Select_from_array (no relationship, 1-1 or 1-n)')
+                ->options(['one' => 'One', 'two' => 'Two', 'three' => 'Three'])
+                ->allows_null(true)
+                ->allows_multiple(false)
+                ->wrapperAttributes(['class' => 'form-group col-md-6'])
+                ->tab('Selects');
 
-        CRUD::addField([ // select2_from_array
-            'name'              => 'select2_from_array',
-            'label'             => 'Select2_from_array (no relationship, 1-1 or 1-n)',
-            'type'              => 'select2_from_array',
-            'options'           => ['one' => 'One', 'two' => 'Two', 'three' => 'Three'],
-            'allows_null'       => true,
-            'tab'               => 'Selects',
-            'allows_multiple'   => false, // OPTIONAL; needs you to cast this to array in your model;
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-        ]);
+        CRUD::field('select2_from_array')
+                ->type('select2_from_array')
+                ->label('Select2_from_array (no relationship, 1-1 or 1-n)')
+                ->options(['one' => 'One', 'two' => 'Two', 'three' => 'Three'])
+                ->allows_null(true)
+                ->allows_multiple(false)
+                ->wrapperAttributes(['class' => 'form-group col-md-6'])
+                ->tab('Selects');
 
-        CRUD::addField([ // select_and_order
-            'name'    => 'select_and_order',
-            'label'   => 'Select_and_order',
-            'type'    => 'select_and_order',
-            'options' => [
-                1 => 'Option 1',
-                2 => 'Option 2',
-                3 => 'Option 3',
-                4 => 'Option 4',
-                5 => 'Option 5',
-                6 => 'Option 6',
-                7 => 'Option 7',
-                8 => 'Option 8',
-                9 => 'Option 9',
-            ],
-            'fake' => true,
-            'tab'  => 'Selects',
-        ]);
+        CRUD::field('select_and_order')
+                ->type('select_and_order')
+                ->label('Select and order')
+                ->options([
+                    1 => 'Option 1',
+                    2 => 'Option 2',
+                    3 => 'Option 3',
+                    4 => 'Option 4',
+                    5 => 'Option 5',
+                    6 => 'Option 6',
+                    7 => 'Option 7',
+                    8 => 'Option 8',
+                    9 => 'Option 9',
+                ])
+                ->fake(true)
+                ->tab('Selects');
 
         // -----------------
         // UPLOADS tab
         // -----------------
 
         if (app('env') == 'production') {
-            CRUD::addField([   // CustomHTML
-                'name'      => 'separator',
-                'type'      => 'custom_html',
-                'value'     => '<p><small><strong>Note: </strong>In the online demo we\'ve restricted the upload and media library fields a lot, or hidden them entirely. To test them out, you can <a target="_blank" href="https://backpackforlaravel.com/docs/demo">download and install this demo admin panel</a> in your local environment.</small></p>',
-                'tab'       => 'Uploads',
-            ]);
+            CRUD::field('separator')
+                ->type('custom_html')
+                ->value('<p><small><strong>Note: </strong>In the online demo we\'ve restricted the upload and media library fields a lot, or hidden them entirely. To test them out, you can <a target="_blank" href="https://backpackforlaravel.com/docs/demo">download and install this demo admin panel</a> in your local environment.</small></p>')
+                ->tab('Uploads');
         }
 
-        CRUD::addField([   // Browse
-            'name'  => 'browse',
-            'label' => 'Browse (using elFinder)',
-            'type'  => 'browse',
-            'tab'   => 'Uploads',
-        ]);
+        CRUD::field('browse')
+                ->type('browse')
+                ->label('Browse (using elFinder)')
+                ->tab('Uploads');
 
-        CRUD::addField([   // Browse multiple
-            'name'     => 'browse_multiple',
-            'label'    => 'Browse multiple',
-            'type'     => 'browse_multiple',
-            'tab'      => 'Uploads',
-            'sortable' => true,
-            // 'multiple' => true, // enable/disable the multiple selection functionality
-            // 'mime_types' => null, // visible mime prefixes; ex. ['image'] or ['application/pdf']
-        ]);
+        CRUD::field('browse_multiple')
+                ->type('browse_multiple')
+                ->label('Browse multiple')
+                ->sortable(true)
+                // ->multiple(true)
+                // ->mime_types(null)
+                ->tab('Uploads');
 
-        CRUD::addField([   // Upload
-            'name'   => 'upload',
-            'label'  => 'Upload',
-            'type'   => 'upload',
-            'upload' => true,
-            'disk'   => 'uploads', // if you store files in the /public folder, please ommit this; if you store them in /storage or S3, please specify it;
-            // optional:
-            // 'temporary' => 10 // if using a service, such as S3, that requires you to make temporary URL's this will make a URL that is valid for the number of minutes specified
-            'tab' => 'Uploads',
-        ]);
+        CRUD::field('upload')
+                ->type('upload')
+                ->label('Upload')
+                ->upload(true)
+                ->disk('uploads')
+                ->tab('Uploads');
 
-        CRUD::addField([   // Upload
-            'name'   => 'upload_multiple',
-            'label'  => 'Upload Multiple',
-            'type'   => 'upload_multiple',
-            'upload' => true,
-            // 'disk' => 'uploads', // if you store files in the /public folder, please ommit this; if you store them in /storage or S3, please specify it;
-            // optional:
-            // 'temporary' => 10 // if using a service, such as S3, that requires you to make temporary URL's this will make a URL that is valid for the number of minutes specified
-            'tab' => 'Uploads',
-        ]);
+        CRUD::field('upload_multiple')
+                ->type('upload_multiple')
+                ->upload(true)
+                ->tab('Uploads');
 
-        CRUD::addField([ // base64_image
-            'label'        => 'Base64 Image - includes cropping',
-            'name'         => 'base64_image',
-            'filename'     => null, // set to null if not needed
-            'type'         => 'base64_image',
-            'aspect_ratio' => 1, // set to 0 to allow any aspect ratio
-            'crop'         => true, // set to true to allow cropping, false to disable
-            'src'          => null, // null to read straight from DB, otherwise set to model accessor function
-            'tab'          => 'Uploads',
-        ]);
+        CRUD::field('base64_image')
+                ->type('base64_image')
+                ->label('Base64 Image - includes cropping')
+                ->crop(true)
+                ->filename(null)
+                ->aspect_ratio(1)
+                ->src(null) // null to read straight from DB, else model accessor
+                ->tab('Uploads');
 
-        CRUD::addField([ // image
-            'label'        => 'Image - includes cropping',
-            'name'         => 'image',
-            'type'         => 'image',
-            'upload'       => true,
-            'crop'         => true, // set to true to allow cropping, false to disable
-            'aspect_ratio' => 1, // ommit or set to 0 to allow any aspect ratio
-            // 'disk' => config('backpack.base.root_disk_name'), // in case you need to show images from a different disk
-            // 'prefix' => 'uploads/images/profile_pictures/' // in case your db value is only the file name (no path), you can use this to prepend your path to the image src (in HTML), before it's shown to the user;
-            'tab' => 'Uploads',
-        ]);
+        CRUD::field('image')
+                ->type('image')
+                ->label('Image - includes cropping')
+                ->upload(true)
+                ->crop(true)
+                ->aspect_ratio(1)
+                ->src(null) // null to read straight from DB, else model accessor
+                ->tab('Uploads');
 
         // -----------------
         // BIG TEXTS tab
         // -----------------
-        CRUD::addField([   // SimpleMDE
-            'name'  => 'simplemde',
-            'label' => 'SimpleMDE - markdown editor',
-            'type'  => 'simplemde',
-            'tab'   => 'Big texts',
-        ]);
 
-        CRUD::addField([   // Summernote
-            'name'  => 'summernote',
-            'label' => 'Summernote editor',
-            'type'  => 'summernote',
-            'tab'   => 'Big texts',
-        ]);
+        CRUD::field('simplemde')
+                ->type('simplemde')
+                ->label('SimpleMDE - markdown editor')
+                ->tab('Big texts');
 
-        CRUD::addField([   // CKEditor
-            'name'  => 'wysiwyg',
-            'label' => 'CKEditor - also called the WYSIWYG field',
-            'type'  => 'ckeditor',
-            'tab'   => 'Big texts',
-        ]);
+        CRUD::field('summernote')
+                ->type('summernote')
+                ->label('Summernote editor')
+                ->tab('Big texts');
 
-        CRUD::addField([   // TinyMCE
-            'name'  => 'tinymce',
-            'label' => 'TinyMCE',
-            'type'  => 'tinymce',
-            'tab'   => 'Big texts',
-        ]);
+        CRUD::field('wysiwyg')
+                ->type('ckeditor')
+                ->label('CKEditor - also called the WYSIWYG field')
+                ->tab('Big texts');
+
+        CRUD::field('tinymce')
+                ->type('tinymce')
+                ->label('TinyMCE')
+                ->tab('Big texts');
 
         // -----------------
         // MISCELLANEOUS tab
         // -----------------
-        CRUD::addField([   // Color
-            'name'  => 'color',
-            'label' => 'Color picker (HTML5 spec)',
-            'type'  => 'color',
-            // 'wrapperAttributes' => ['class' => 'col-md-6'],
-            'tab'               => 'Miscellaneous',
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-        ]);
-        CRUD::addField([   // Color
-            'name'  => 'color_picker',
-            'label' => 'Color picker (jQuery plugin)',
-            'type'  => 'color_picker',
-            // 'wrapperAttributes' => ['class' => 'col-md-6'],
-            'tab'               => 'Miscellaneous',
-            'wrapperAttributes' => ['class' => 'form-group col-md-6'],
-        ]);
 
-        CRUD::addField([
-            'label'   => 'Icon Picker',
-            'name'    => 'icon_picker',
-            'type'    => 'icon_picker',
-            'iconset' => 'fontawesome', // options: fontawesome, glyphicon, ionicon, weathericon, mapicon, octicon, typicon, elusiveicon, materialdesign
-            'tab'     => 'Miscellaneous',
-        ]);
+        CRUD::field('color')
+                ->type('color')
+                ->label('Color picker (HTML5 spec)')
+                ->wrapperAttributes(['class' => 'form-group col-md-5'])
+                ->tab('Miscellaneous');
 
-        CRUD::addField([ // Table
-            'name'            => 'table',
-            'label'           => 'Table',
-            'type'            => 'table',
-            'entity_singular' => 'subentry', // used on the "Add X" button
-            'columns'         => [
-                'name'  => 'Name',
-                'desc'  => 'Description',
-                'price' => 'Price',
-            ],
-            'max' => 5, // maximum rows allowed in the table
-            'min' => 0, // minimum rows allowed in the table
-            'tab' => 'Miscellaneous',
-        ]);
+        CRUD::field('color_picker')
+                ->type('color_picker')
+                ->label('Color picker (jQuery plugin)')
+                ->wrapperAttributes(['class' => 'form-group col-md-5'])
+                ->tab('Miscellaneous');
 
-        CRUD::addField([ // Table
-            'name'            => 'fake_table',
-            'label'           => 'Fake Table',
-            'type'            => 'table',
-            'entity_singular' => 'subentry', // used on the "Add X" button
-            'columns'         => [
-                'name'  => 'Name',
-                'desc'  => 'Description',
-                'price' => 'Price',
-            ],
-            'fake' => true,
-            'max'  => 5, // maximum rows allowed in the table
-            'min'  => 0, // minimum rows allowed in the table
-            'tab'  => 'Miscellaneous',
-        ]);
+        CRUD::field('icon_picker')
+                ->type('icon_picker')
+                ->label('Icon Picker')
+                ->iconset('fontawesome')
+                ->wrapperAttributes(['class' => 'form-group col-md-2'])
+                ->tab('Miscellaneous');
+
+        CRUD::field('table')
+                ->type('table')
+                ->label('Table')
+                ->columns([
+                    'name'  => 'Name',
+                    'desc'  => 'Description',
+                    'price' => 'Price',
+                ])
+                ->min(0)
+                ->max(5)
+                ->tab('Miscellaneous');
+
+        CRUD::field('fake_table')
+                ->type('table')
+                ->label('Fake Table')
+                ->fake(true)
+                ->columns([
+                    'name'  => 'Name',
+                    'desc'  => 'Description',
+                    'price' => 'Price',
+                ])
+                ->min(0)
+                ->max(5)
+                ->tab('Miscellaneous');
 
         // $table->string('url')->nullable;
         // $table->text('video')->nullable;
-        CRUD::addField([   // URL
-            'name'  => 'video',
-            'label' => 'Video - link to video file on Youtube or Vimeo',
-            'type'  => 'video',
-            'tab'   => 'Miscellaneous',
-        ]);
+        CRUD::field('video')
+                ->type('video')
+                ->label('Video - link to video file on Youtube or Vimeo')
+                ->tab('Miscellaneous');
         // $table->string('range')->nullable;
 
-        // CRUD::removeField('name', 'update/create/both');
+        // CRUD::field('text')->remove();
     }
 
     protected function setupUpdateOperation()

--- a/app/Http/Controllers/Admin/MonsterCrudController.php
+++ b/app/Http/Controllers/Admin/MonsterCrudController.php
@@ -264,27 +264,27 @@ class MonsterCrudController extends CrudController
         ]);
 
         $this->crud->addField([   // Number
-            'name'  => 'number',
-            'label' => 'Number',
-            'type'  => 'number',
+            'name'              => 'number',
+            'label'             => 'Number',
+            'type'              => 'number',
             'tab'               => 'Simple',
             'wrapperAttributes' => ['class' => 'form-group col-md-3'],
         ]);
 
         $this->crud->addField([   // Number
-            'name'  => 'float',
-            'label' => 'Float',
-            'type'  => 'number',
-            'attributes' => ['step' => 'any'], // allow decimals
+            'name'              => 'float',
+            'label'             => 'Float',
+            'type'              => 'number',
+            'attributes'        => ['step' => 'any'], // allow decimals
             'tab'               => 'Simple',
             'wrapperAttributes' => ['class' => 'form-group col-md-3'],
         ]);
 
         $this->crud->addField([   // Number
-            'name'  => 'number_with_prefix',
-            'label' => 'Number with prefix',
-            'type'  => 'number',
-            'prefix' => '$',
+            'name'              => 'number_with_prefix',
+            'label'             => 'Number with prefix',
+            'type'              => 'number',
+            'prefix'            => '$',
             'fake'              => true,
             'store_in'          => 'extras',
             'tab'               => 'Simple',
@@ -292,9 +292,9 @@ class MonsterCrudController extends CrudController
         ]);
 
         $this->crud->addField([   // Number
-            'name'  => 'number_with_suffix',
-            'label' => 'Number with suffix',
-            'type'  => 'number',
+            'name'              => 'number_with_suffix',
+            'label'             => 'Number with suffix',
+            'type'              => 'number',
             'suffix'            => '.00',
             'fake'              => true,
             'store_in'          => 'extras',

--- a/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
@@ -37,3 +37,4 @@
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('monster') }}"><i class="nav-icon la la-optin-monster"></i> <span>Monsters</span></a></li>
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('icon') }}"><i class="nav-icon la la-info-circle"></i> <span>Icons</span></a></li>
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('product') }}"><i class="nav-icon la la-shopping-cart"></i> <span>Products</span></a></li>
+<li class="nav-item"><a class="nav-link" href="{{ backpack_url('fluent-monster') }}"><i class="nav-icon la la-pastafarianism"></i> <span>Fluent Monsters</span></a></li>

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -19,6 +19,7 @@ Route::group([
     // CRUDs
     // -----
     Route::crud('monster', 'MonsterCrudController');
+    Route::crud('fluent-monster', 'FluentMonsterCrudController');
     Route::crud('icon', 'IconCrudController');
     Route::crud('product', 'ProductCrudController');
 


### PR DESCRIPTION
Includes examples on using the new Fluent syntax in 4.1, for Fields, Columns, Filters. 

See:

- https://github.com/Laravel-Backpack/CRUD/pull/2513
- https://github.com/Laravel-Backpack/CRUD/pull/2572
- https://github.com/Laravel-Backpack/CRUD/pull/2599