### PR TITLE
Provide docker-compose example and instructions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.8"
+
+volumes:
+  mysql57:
+    name: mysql57
+
+services:
+  db:
+    image: mysql:5.7
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: asdf
+      MYSQL_DATABASE: backpackdemo
+    volumes:
+      - mysql57:/var/lib/mysql
+
+  web:
+    image: webdevops/php-nginx:7.4-alpine
+    ports:
+      - 80:80
+    volumes:
+      - ./:/app
+    working_dir: /app
+    environment:
+      WEB_DOCUMENT_ROOT: /app/public
+      WEB_ALIAS_DOMAIN: localhost

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ cp .env.example .env
 php artisan key:generate
 ```
 
-Use this parameters in your .env file
+Use these parameters in your .env file
 
 ```
 APP_URL=http://localhost
@@ -131,4 +131,3 @@ If you are looking for a developer/team to help you build an admin panel on Lara
 
 [link-author]: http://tabacitu.ro
 [link-contributors]: ../../contributors
-

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,62 @@ Note: Depending on your configuration you may need to define a site within NGINX
 
 ![Example generated CRUD interface](https://backpackforlaravel.com/uploads/docs-4-0/getting_started/tag_crud_list_entries.png)
 
+## If using docker
+
+This package provides an example `docker-compose.yml` to launch your database and web server easily
+
+```
+composer install
+cp .env.example .env
+php artisan key:generate
+```
+
+Use this parameters in your .env file
+
+```
+APP_URL=http://localhost
+DB_CONNECTION=mysql
+DB_HOST=db
+DB_PORT=3306
+DB_DATABASE=backpackdemo
+DB_USERNAME=root
+DB_PASSWORD=asdf
+```
+
+Launch docker
+
+```
+docker-compose up -d
+```
+
+Create your database with following command
+
+```
+docker-compose exec db mysql -u root -pasdf -e "create database if not exists backpackdemo;"
+```
+
+Migrate and seed
+
+```
+php artisan migrate --seed
+```
+
+You should see the demo in your browser now
+
+```
+http://localhost/admin
+```
+
+To stop the server simply run
+
+```
+docker-compose down
+```
+
+Note: 
+
+In docker, to connect to your database from your GUI use `127.0.0.1` as your database host, instead of `localhost`
+
 ## Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.


### PR DESCRIPTION
@tabacitu  If following the readme step by step, this docker method is almost fail proof. 

Note: In a strict sense, the correct way of using composer and php with docker is using:

`docker-compose exec web composer`
`docker-compose exec web php`

(because the `web` service is the one with composer and php)

would it may be confusing for beginners... or not? idk, let me know

Note: forked from 4.1 because master threw some errors on `composer install`