### PR TITLE
fix post update asset publishing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         ],
         "post-update-cmd": [
             "Illuminate\\Foundation\\ComposerScripts::postUpdate",
-            "php artisan vendor:publish --provider='Backpack\\CRUD\\BackpackServiceProvider' --tag=public --force"
+            "php artisan vendor:publish --provider=\"Backpack\\CRUD\\BackpackServiceProvider\" --tag=public --force"
         ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",


### PR DESCRIPTION
This was failing (atleast for me in windows)

![image](https://user-images.githubusercontent.com/7188159/102211203-2f6eb600-3ecb-11eb-8185-f32eaf62534c.png)

It's working with this fix. Could you test in in your environment if it still work for you @tabacitu ?