### PR TITLE
Replaced onreadystatechange assign with and addEventListener

### DIFF
--- a/resources/views/vendor/backpack/base/inc/alerts.blade.php
+++ b/resources/views/vendor/backpack/base/inc/alerts.blade.php
@@ -2,7 +2,7 @@
 <script type="text/javascript">
     // This is intentionaly run after dom loads so this way we can avoid showing duplicate alerts
     // when the user is beeing redirected by persistent table, that happens before this event triggers.
-document.onreadystatechange = function () {
+document.addEventListener('readystatechange', () => {
     if (document.readyState == "interactive") {
         Noty.overrideDefaults({
             layout: 'topRight',


### PR DESCRIPTION
@tabacitu I think we should opt for an `addEventListener` instead of assigning to the `document.onreadystatechange` attribute.
That way we avoid conflicts with developers code and future us ✌

Can you test this branch on demo? It should work, but since I can't test, we never know 😅