### PR TITLE
Revert "Minor fix to allow prefixed databases"

### DIFF
--- a/database/migrations/2017_04_20_100848_create_monsters_table.php
+++ b/database/migrations/2017_04_20_100848_create_monsters_table.php
@@ -59,7 +59,6 @@ class CreateMonstersTable extends Migration
             $table->timestamps();
         });
 
-        DB::statement('ALTER TABLE monsters MODIFY base64_image MEDIUMBLOB');
     }
 
     /**

--- a/database/migrations/2017_04_20_100848_create_monsters_table.php
+++ b/database/migrations/2017_04_20_100848_create_monsters_table.php
@@ -59,8 +59,7 @@ class CreateMonstersTable extends Migration
             $table->timestamps();
         });
 
-        $prefix = DB::getTablePrefix();
-        DB::statement("ALTER TABLE {$prefix}monsters MODIFY base64_image MEDIUMBLOB");
+        DB::statement('ALTER TABLE monsters MODIFY base64_image MEDIUMBLOB');
     }
 
     /**

--- a/database/migrations/2017_04_20_100848_create_monsters_table.php
+++ b/database/migrations/2017_04_20_100848_create_monsters_table.php
@@ -58,7 +58,6 @@ class CreateMonstersTable extends Migration
             $table->text('extras')->nullable();
             $table->timestamps();
         });
-
     }
 
     /**


### PR DESCRIPTION
Reverts Laravel-Backpack/demo#203 in order to fix https://github.com/Laravel-Backpack/demo/issues/242

After this revert, demo migrations work again on PostgreSQL since there's no raw db statement. With the obvious caveat being that Laravel-Backpack/demo#203 is no longer fixed.