### PR TITLE
add MVP for testing all crud.field JS library features

### DIFF
--- a/app/Http/Controllers/Admin/FieldMonsterCrudController.php
+++ b/app/Http/Controllers/Admin/FieldMonsterCrudController.php
@@ -2,10 +2,8 @@
 
 namespace App\Http\Controllers\Admin;
 
-use App\Http\Requests\MonsterRequest as StoreRequest;
-use Backpack\CRUD\app\Library\Widget;
-use Backpack\CRUD\app\Http\Controllers\CrudController;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+use Backpack\CRUD\app\Library\Widget;
 
 class FieldMonsterCrudController extends MonsterCrudController
 {
@@ -48,16 +46,16 @@ class FieldMonsterCrudController extends MonsterCrudController
 
         // MUST: when a checkbox is checked, show a second field;
         CRUD::field('visible')->type('checkbox')->fake(true)->tab('Top 10 Scenarios');
-        CRUD::field('visible_where')->type('text')->fake(true)->wrapperAttributes([ 'class' => 'form-group col-sm-11 offset-1'])->tab('Top 10 Scenarios');
+        CRUD::field('visible_where')->type('text')->fake(true)->wrapperAttributes(['class' => 'form-group col-sm-11 offset-1'])->tab('Top 10 Scenarios');
 
         // MUST: when a checkbox is checked, show a second field AND un-disable/un-readonly it;
         CRUD::field('displayed')->type('checkbox')->fake(true)->tab('Top 10 Scenarios');
-        CRUD::field('displayed_where')->type('text')->fake(true)->wrapperAttributes([ 'class' => 'form-group col-sm-11 offset-1'])->tab('Top 10 Scenarios');
+        CRUD::field('displayed_where')->type('text')->fake(true)->wrapperAttributes(['class' => 'form-group col-sm-11 offset-1'])->tab('Top 10 Scenarios');
 
         // MUST: when a radio has something specific selected, show a second field;
         CRUD::field('type')->type('radio')->options(['Type A', 'Type B', 'Type C', 'Other'])->inline(true)->fake(true)->tab('Top 10 Scenarios');
         // when type is Other, show an input to specify its type
-        CRUD::field('custom_type')->type('text')->fake(true)->wrapperAttributes([ 'class' => 'form-group col-sm-11 offset-1'])->tab('Top 10 Scenarios');
+        CRUD::field('custom_type')->type('text')->fake(true)->wrapperAttributes(['class' => 'form-group col-sm-11 offset-1'])->tab('Top 10 Scenarios');
 
         // MUST: when a select has something specific selected, show a second field;
         CRUD::field('parent')->type('select_from_array')->options([
@@ -68,8 +66,8 @@ class FieldMonsterCrudController extends MonsterCrudController
             5 => 'Parent 5',
             6 => 'Parent 6',
             6 => 'Other',
-        ])->fake(true)->wrapperAttributes([ 'class' => 'form-group col-sm-6'])->tab('Top 10 Scenarios');
-        CRUD::field('custom_parent')->type('text')->fake(true)->wrapperAttributes([ 'class' => 'form-group col-sm-6'])->tab('Top 10 Scenarios');
+        ])->fake(true)->wrapperAttributes(['class' => 'form-group col-sm-6'])->tab('Top 10 Scenarios');
+        CRUD::field('custom_parent')->type('text')->fake(true)->wrapperAttributes(['class' => 'form-group col-sm-6'])->tab('Top 10 Scenarios');
         CRUD::field('another_separator')->type('custom_html')->value('<hr>')->tab('Top 10 Scenarios');
 
         // MUST: when a checkbox is checked AND a select has a certain value, then show a third field;
@@ -93,5 +91,4 @@ class FieldMonsterCrudController extends MonsterCrudController
         CRUD::field('discounted_price')->type('number')->size(4)->tab('Top 10 Scenarios');
         CRUD::field('discount_percentage')->type('number')->size(4)->tab('Top 10 Scenarios');
     }
-
 }

--- a/app/Http/Controllers/Admin/FieldMonsterCrudController.php
+++ b/app/Http/Controllers/Admin/FieldMonsterCrudController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Requests\MonsterRequest as StoreRequest;
+use Backpack\CRUD\app\Library\Widget;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+class FieldMonsterCrudController extends MonsterCrudController
+{
+    public function setup()
+    {
+        $this->crud->setModel(\App\Models\Monster::class);
+        $this->crud->setRoute(config('backpack.base.route_prefix').'/field-monster');
+        $this->crud->setEntityNameStrings('field monster', 'field monsters');
+
+        $this->crud->set('show.setFromDb', false);
+    }
+
+    protected function setupCreateOperation()
+    {
+        parent::setupCreateOperation();
+
+        $this->setupFieldsForTopScenarios();
+
+        // TODO: remove this when the date_range field works ok
+        CRUD::removeField('start_date_end_date');
+
+        // load all the fields as a JS array
+        Widget::add()->type('script')->content('assets/js/monster/fields.js');
+        // then test each crud.field() method individually
+        Widget::add()->type('script')->content('assets/js/monster/test-hide-field.js');
+        Widget::add()->type('script')->content('assets/js/monster/test-show-field.js');
+        // Widget::add()->type('script')->content('assets/js/monster/test-enable-field.js');
+        // Widget::add()->type('script')->content('assets/js/monster/test-disable-field.js');
+        // Widget::add()->type('script')->content('assets/js/monster/test-require-field.js');
+        // Widget::add()->type('script')->content('assets/js/monster/test-unrequire-field.js');
+        // Widget::add()->type('script')->content('assets/js/monster/test-custom-field.js');
+        // Widget::add()->type('script')->content('assets/js/monster/test-onchange-field.js');
+    }
+
+    protected function setupFieldsForTopScenarios()
+    {
+        Widget::add()->type('script')->content('assets/js/monster/test-top-scenarios.js');
+
+        CRUD::field('notice')->type('custom_html')->value('<i class="text-small">This tab shows the Top 10 Scenarios that the crud.field() JS library covers. These fields will NOT hide/show/etc when the buttons above are clicked, that\'s ok, don\'t worry.</i><hr>')->tab('Top 10 Scenarios');
+
+        // MUST: when a checkbox is checked, show a second field;
+        CRUD::field('visible')->type('checkbox')->fake(true)->tab('Top 10 Scenarios');
+        CRUD::field('visible_where')->type('text')->fake(true)->wrapperAttributes([ 'class' => 'form-group col-sm-11 offset-1'])->tab('Top 10 Scenarios');
+
+        // MUST: when a checkbox is checked, show a second field AND un-disable/un-readonly it;
+        CRUD::field('displayed')->type('checkbox')->fake(true)->tab('Top 10 Scenarios');
+        CRUD::field('displayed_where')->type('text')->fake(true)->wrapperAttributes([ 'class' => 'form-group col-sm-11 offset-1'])->tab('Top 10 Scenarios');
+
+        // MUST: when a radio has something specific selected, show a second field;
+        CRUD::field('type')->type('radio')->options(['Type A', 'Type B', 'Type C', 'Other'])->inline(true)->fake(true)->tab('Top 10 Scenarios');
+        // when type is Other, show an input to specify its type
+        CRUD::field('custom_type')->type('text')->fake(true)->wrapperAttributes([ 'class' => 'form-group col-sm-11 offset-1'])->tab('Top 10 Scenarios');
+
+        // MUST: when a select has something specific selected, show a second field;
+        CRUD::field('parent')->type('select_from_array')->options([
+            1 => 'Parent 1',
+            2 => 'Parent 2',
+            3 => 'Parent 3',
+            4 => 'Parent 4',
+            5 => 'Parent 5',
+            6 => 'Parent 6',
+            6 => 'Other',
+        ])->fake(true)->wrapperAttributes([ 'class' => 'form-group col-sm-6'])->tab('Top 10 Scenarios');
+        CRUD::field('custom_parent')->type('text')->fake(true)->wrapperAttributes([ 'class' => 'form-group col-sm-6'])->tab('Top 10 Scenarios');
+        CRUD::field('another_separator')->type('custom_html')->value('<hr>')->tab('Top 10 Scenarios');
+
+        // MUST: when a checkbox is checked AND a select has a certain value, then show a third field;
+        // done, re-used displayed and parent
+
+        // MUST: when a checkbox is checked OR a select has a certain value, then show a third field;
+        // done, re-used displayed and parent
+
+        // SHOULD: when a select is a certain value, show a second field; if it's another value, show a third field;
+        // done, re-used category
+
+        // SHOULD: when a checkbox is checked, automatically check a different checkbox or radio;
+        // done, re-used visible, it now checks displayed
+
+        // COULD: when a text input is written into, write into a second input (eg. slug);
+        CRUD::field('title')->size(6)->tab('Top 10 Scenarios');
+        CRUD::field('slug')->size(6)->tab('Top 10 Scenarios');
+
+        // COULD: when multiple inputs change, change a last input to calculate the total or smth;
+        CRUD::field('full_price')->type('number')->size(4)->tab('Top 10 Scenarios');
+        CRUD::field('discounted_price')->type('number')->size(4)->tab('Top 10 Scenarios');
+        CRUD::field('discount_percentage')->type('number')->size(4)->tab('Top 10 Scenarios');
+    }
+
+}

--- a/public/assets/js/monster/fields.js
+++ b/public/assets/js/monster/fields.js
@@ -1,0 +1,70 @@
+/**
+ * This file includes all the fields inside Monster,
+ * as an array, in order to be used for testing
+ * the crud.field() JS library.
+ */
+
+var monsterFields = [
+    // ---------------------------------
+    // Monster Fields, by Name and Type
+    // ---------------------------------
+    // syntax: 'fieldName', // fieldType
+    // ---------------------------------
+    'checkbox', // checkbox
+    'roles', // checklist
+    // checklist_dependency
+    'color', // color
+    // custom_html
+    'date', // date
+    'datetime', // datetime
+    'email', // email
+    // enum
+    'hidden', // hidden
+    'month', // month
+    'number', 'float', 'number_with_prefix', 'number_with_suffix', 'text_with_both_prefix_and_suffix', // number
+    'password', // password
+    'radio', // radio
+    'range', // range
+    'select', // select (1-n relationship)
+    'select_grouped_id', // select_grouped
+    'tags', // select_multiple (n-n relationship)
+    'select_from_array', // select_from_array
+    'summernote', // summernote
+    'text', // text
+    'textarea', // textarea
+    'time', // time
+    'upload', // upload
+    'upload_multiple', // upload_multiple
+    'url', // url
+    // view
+    'week', // week
+    'address_algolia', 'address_algolia_string', // address_algolia PRO
+    // address_google PRO
+    'browse', // browse PRO
+    'browse_multiple', // browse_multiple PRO
+    'base64_image', // base64_image PRO
+    'wysiwyg', // ckeditor PRO
+    'color_picker', // color_picker PRO
+    'start_date', 'end_date', // date_range PRO
+    'date_picker', // date_picker PRO
+    'datetime_picker', // datetime_picker PRO
+    'easymde', // easymde PRO
+    'icon_picker', // icon_picker PRO
+    'image', // image PRO
+    // relationship PRO
+    // repeatable PRO
+    'select2', // select2 (1-n relationship) PRO
+    'categories', // select2_multiple (n-n relationship) PRO
+    'select2_nested_id', // select2_nested PRO
+    'select2_grouped_id', // select2_grouped PRO
+    'select_and_order', // select_and_order PRO
+    'select2_from_array', // select2_from_array PRO
+    'select2_from_ajax', // select2_from_ajax PRO
+    'articles', // select2_from_ajax_multiple PRO
+    'table', 'fake_table', // table PRO
+    'tinymce', // tinymce PRO
+    'video', // video PRO
+    // 'wysiwyg', // wysiwyg PRO - included in ckeditor and summernote
+];
+
+// console.log(monsterFields);

--- a/public/assets/js/monster/test-hide-field.js
+++ b/public/assets/js/monster/test-hide-field.js
@@ -1,0 +1,17 @@
+/**
+ * This file tests the crud.field('name').hide() method
+ * on all Monster field types, assuming the fields.js
+ * file is already loaded.
+ */
+
+$('nav[aria-label=breadcrumb]').append('<a class="btn btn-warning ml-4 mb-4" href="javascript:testCrudFieldHide()">Test crud.field.hide()</a>');
+
+function testCrudFieldHide() {
+    // go through all Monster fields and hide them
+    for (var i = 0; i <= monsterFields.length - 1; i++) {
+        crud.field(monsterFields[i]).hide();
+    }
+
+    alert('Calling hide() on all monster fields. If you can see a field... then hide() doesn\'t work on it, please investigate.');
+}
+

--- a/public/assets/js/monster/test-show-field.js
+++ b/public/assets/js/monster/test-show-field.js
@@ -1,0 +1,17 @@
+/**
+ * This file tests the crud.field('name').show() method
+ * on all Monster field types, assuming the fields.js
+ * file is already loaded.
+ */
+
+$('nav[aria-label=breadcrumb]').append('<a class="btn btn-warning ml-1 mb-4" href="javascript:testCrudFieldShow()">Test crud.field.show()</a>');
+
+function testCrudFieldShow() {
+    // go through all Monster fields and hide them
+    for (var i = 0; i <= monsterFields.length - 1; i++) {
+        crud.field(monsterFields[i]).show();
+    }
+
+    alert('Calling show() on all monster fields. If you can\'t see a field... then show() doesn\'t work on it, please investigate.');
+}
+

--- a/public/assets/js/monster/test-top-scenarios.js
+++ b/public/assets/js/monster/test-top-scenarios.js
@@ -1,0 +1,136 @@
+ // EXAMPLE 1
+ // MUST: when a checkbox is checked, show a second field;
+ crud.field('visible').onChange(function(e, value) {
+    if (value == 1) {
+        crud.field('visible_where').show();
+    } else {
+        crud.field('visible_where').hide();
+    }
+ });
+
+ // EXAMPLE 2
+ // MUST: when a checkbox is checked, show a second field AND un-disable/un-readonly it;
+ crud.field('displayed').change(function(e, value) {
+    if (value == 1) {
+        crud.field('displayed_where').show().enable();
+    } else {
+        crud.field('displayed_where').hide().disable();
+    }
+ });
+
+ // EXAMPLE 3
+ // MUST: when a radio has something specific selected, show a second field;
+ crud.field('type').change(function(e, value) {
+    if (value == 3) {
+        crud.field('custom_type').show();
+    } else {
+        crud.field('custom_type').hide();
+    }
+ });
+
+ // EXAMPLE 4
+ // MUST: when a select has something specific selected, show a second field;
+ crud.field('parent').change(function(e, value) {
+    if (value == 6) {
+        crud.field('custom_parent').show();
+    } else {
+        crud.field('custom_parent').hide();
+    }
+ });
+
+ // EXAMPLE 5
+ // MUST: when a checkbox is checked AND a select has a certain value, then do something;
+ function do_something() {
+    console.log('Displayed AND custom parent.');
+ }
+ crud.field('displayed').change(function(e, value) {
+    if (value == 1 && crud.field('parent').value == 6) {
+        do_something();
+    }
+ });
+ crud.field('parent').change(function(e, value) {
+    if (value == 6 && crud.field('displayed').value == 1) {
+        do_something();
+    }
+ });
+
+ // EXAMPLE 6
+ // MUST: when a checkbox is checked OR a select has a certain value, then show a third field;
+ function do_something_else() {
+    console.log('Displayed OR custom parent.');
+ }
+ crud.field('displayed').change(function(e, value) {
+    if (value == 1 || crud.field('parent').value == 6) {
+        do_something_else();
+    }
+ });
+ crud.field('parent').change(function(e, value) {
+    if (value == 6 || crud.field('displayed').value == 1) {
+        do_something_else();
+    }
+ });
+
+ // EXAMPLE 7
+ // SHOULD: when a select is a certain value, show a second field; if it's another value, show a third field;
+ crud.field('category_id').change(function(e, value) {
+    switch(value) {
+      case "2":
+        console.log('fake showing a second field');
+        // crud.field('second_field').show();
+        break;
+      case "3":
+        console.log('fake showing a third field');
+        // crud.field('third_field').show();
+        break;
+      default:
+        console.log('not doing anything');
+    }
+ })
+
+ // EXAMPLE 8
+ // SHOULD: when a checkbox is checked, automatically check a different checkbox or radio;
+ crud.field('visible').change(function(e, value) {
+    if (value == 1) {
+        crud.field('displayed').check();
+    } else {
+        crud.field('displayed').uncheck();
+    }
+ });
+
+ // EXAMPLE 9
+ // COULD: when a text input is written into, write into a second input (eg. slug);
+ function slugify(string) {
+  const a = 'àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìıİłḿñńǹňôöòóœøōõőṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·/_,:;'
+  const b = 'aaaaaaaaaacccddeeeeeeeegghiiiiiiiilmnnnnoooooooooprrsssssttuuuuuuuuuwxyyzzz------'
+  const p = new RegExp(a.split('').join('|'), 'g')
+
+  return string.toString().toLowerCase()
+    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(p, c => b.charAt(a.indexOf(c))) // Replace special characters
+    .replace(/&/g, '-and-') // Replace & with 'and'
+    .replace(/[^\w\-]+/g, '') // Remove all non-word characters
+    .replace(/\-\-+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, '') // Trim - from end of text
+}
+  crud.field('title').change(function(e, value) {
+    var slug = slugify(value);
+    crud.field('slug').input.val(slug);
+ });
+
+ // EXAMPLE 10
+ // COULD: when multiple inputs change, change a last input to calculate the total or smth;
+ function calculate_discount_percentage() {
+    var full_price = crud.field('full_price').value;
+    var discounted_price = crud.field('discounted_price').value;
+    var discount = full_price - discounted_price;
+    var discount_percentage = discount * 100 / full_price;
+
+    crud.field('discount_percentage').input.val(discount_percentage);
+ }
+
+ $.each(crud.fields(['full_price', 'discounted_price']), function(index, field) {
+    field.change(function(e, value) {
+        calculate_discount_percentage();
+    });
+ });

--- a/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
@@ -54,6 +54,7 @@
       <li class="nav-item"><a class="nav-link" href="{{ backpack_url('icon') }}"><i class="nav-icon la la-info-circle"></i> <span>Icons</span></a></li>
       <li class="nav-item"><a class="nav-link" href="{{ backpack_url('product') }}"><i class="nav-icon la la-shopping-cart"></i> <span>Products</span></a></li>
       <li class="nav-item"><a class="nav-link" href="{{ backpack_url('fluent-monster') }}"><i class="nav-icon la la-pastafarianism"></i> <span>Fluent Monsters</span></a></li>
+      <li class="nav-item"><a class="nav-link" href="{{ backpack_url('field-monster') }}"><i class="nav-icon la la-list-alt"></i> <span>Field Monsters</span></a></li>
       <li class="nav-item"><a class="nav-link" href="{{ backpack_url('dummy') }}"><i class="nav-icon la la-poo"></i> <span>Dummies</span></a></li>
   </ul>
 </li>

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -26,6 +26,7 @@ Route::group([
     // Other entities
     // ----------------
     Route::crud('fluent-monster', 'FluentMonsterCrudController');
+    Route::crud('field-monster', 'FieldMonsterCrudController');
     Route::crud('icon', 'IconCrudController');
     Route::crud('product', 'ProductCrudController');
     Route::crud('dummy', 'DummyCrudController');


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We didn't have a way to test all JS library features introduced by https://github.com/Laravel-Backpack/CRUD/pull/4312

### AFTER - What is happening after this PR?

We do. At least a start for it (@pxpm please help me finish this).

## HOW

### How did you achieve that, in technical terms?

I've added a new CRUD, which I've called `FieldMonster`. In there, we can test the JS functionality alone, on all field types:


https://user-images.githubusercontent.com/1032474/163972180-bdbd9078-2aa7-42b2-95df-45fc4fdd1d39.mp4

So what I want us to do is:
- [x] have the most common scenarios there for us to easily test (added them in a different tab)
- [ ] add buttons that test each method on the fields where it makes sense, and makes it somehow easy for the dev to see if something's not working:
    - [ ] `change()`
    - [x] `hide()`
    - [x] `show()`
    - [ ] `enable()`
    - [ ] `disable()`
    - [ ] `require()`
    - [ ] `unrequire()`
    - [ ] `check()`
    - [ ] `uncheck()`


### Is it a breaking change or non-breaking change?

Non-breaking. Needs assets to be published though, because it adds some JS files.

### How can we test the before & after?

- install the demo
- run `composer require backpack/crud:"dev-crud-form-javascript-library as 5.0.99"` (for now, until it's merged and tagged)
