### PR TITLE
add quick commands for publishing assets and linking/unlinking the as…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,10 @@
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover"
         ],
-        "test": "vendor/bin/phpunit --testdox"
+        "test": "vendor/bin/phpunit --testdox",
+        "bp-assets-publish": "php artisan vendor:publish --provider=\"Backpack\\CRUD\\BackpackServiceProvider\" --tag=public --force",
+        "bp-assets-link": "cd public && rm -rf packages || true && ln -s ../vendor/backpack/crud/src/public/packages && cd ../",
+        "bp-assets-unlink": "rm -rf public/packages || true && composer bp-assets-publish"
     },
     "config": {
         "preferred-install": "dist",


### PR DESCRIPTION
…sets directory from vendor

## WHY

### BEFORE - What was wrong? What was happening before this PR?

You couldn't easily test the published assets, like for https://github.com/Laravel-Backpack/CRUD/issues/4352 

### AFTER - What is happening after this PR?

You can, because you have 3 new commands:
- `composer bp-assets-publish` - will re-publish all Backpack\CRUD assets;
- `composer bp-assets-link` - will delete the `public/packages` dir and create a symlink to the one in vendor;
- `composer bp-assets-unlink` - will undo the above;


## HOW

### How did you achieve that, in technical terms?

Unix commands, added to `composer.json`.

### Is it a breaking change or non-breaking change?

Non-breaking.

### How can we test the before & after?

Run the commands above, if needed.
