### PR TITLE
Add google address field

### DIFF
--- a/app/Http/Controllers/Admin/MonsterCrudController.php
+++ b/app/Http/Controllers/Admin/MonsterCrudController.php
@@ -263,6 +263,17 @@ class MonsterCrudController extends CrudController
         $this->crud->addFields(static::getFieldsArrayForWysiwygEditorsTab());
         $this->crud->addFields(static::getFieldsArrayForMiscellaneousTab());
 
+        if (env('GOOGLE_PLACES_KEY')) {
+            $this->crud->addField([   // Address_google
+                'name'          => 'address_google',
+                'label'         => 'Address_google '.backpack_pro_badge(),
+                'type'          => 'address_google',
+                'fake'          => true,
+                'store_as_json' => true,
+                'tab'           => 'Time and space',
+            ]);
+        }
+
         // if you want to test removeField, uncomment the following line
         // $this->crud->removeField('url');
     }

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,8 @@ return [
         'secret' => env('STRIPE_SECRET'),
     ],
 
+    'google_places' => [
+        'key' => env('GOOGLE_PLACES_KEY'),
+    ],
+
 ];


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

It was difficult to test the `google_address` field, we had to add it every time.

### AFTER - What is happening after this PR?

It's a lot easier to test, because it gets added if you add this to your .env file:

```bash
GOOGLE_PLACES_KEY=xxx
```

(of course `xxx` has to be a valid API key)
