### PR TITLE
Restore select_and_order as a demo field after fix

### DIFF
--- a/app/Http/Controllers/Admin/CaveCrudController.php
+++ b/app/Http/Controllers/Admin/CaveCrudController.php
@@ -83,7 +83,6 @@ class CaveCrudController extends CrudController
             'upload_multiple',
             'select_grouped', // TODO
             'select2_grouped', // TODO
-            'select_and_order', // TODO
         ];
 
         $subfields = array_merge(


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?
Field **select_and_order** was hidden due to problems.

### AFTER - What is happening after this PR?

After this [PR](https://github.com/DigitallyHappy/backpack-pro/pull/61) is merged, we need to restore **select_and_order** as it will be back working.

## HOW

### How did you achieve that, in technical terms?

Remove `select_and_order` from `$field_types_that_dont_work` array.


### Is it a breaking change or non-breaking change?

Non-breaking change.


### How can we test the before & after?

Field **select_and_order** should be visible.
