### PR TITLE
Moved api methods from GET to POST

### DIFF
--- a/app/Http/Controllers/Admin/FluentMonsterCrudController.php
+++ b/app/Http/Controllers/Admin/FluentMonsterCrudController.php
@@ -276,6 +276,7 @@ class FluentMonsterCrudController extends CrudController
                 ->attribute('title')
                 ->model('Backpack\NewsCRUD\app\Models\Article')
                 ->data_source(url('api/article'))
+                ->method('POST')
                 ->placeholder('Select an article')
                 ->minimum_input_length(2)
                 ->wrapper(['class' => 'form-group col-md-6'])
@@ -323,6 +324,7 @@ class FluentMonsterCrudController extends CrudController
                 ->data_source(url('api/article'))
                 ->placeholder('Select one or more articles')
                 ->minimum_input_length(2)
+                ->method('post')
                 ->pivot(true)
                 ->wrapper(['class' => 'form-group col-md-6'])
                 ->tab('Selects');
@@ -612,6 +614,7 @@ class FluentMonsterCrudController extends CrudController
                 ->label('S2 Ajax')
                 ->placeholder('Pick an article')
                 ->values(url('api/article-search'))
+                ->method('POST')
                 ->whenActive(function ($value) {
                     CRUD::addClause('where', 'select2_from_ajax', $value);
                 });

--- a/app/Http/Controllers/Admin/MonsterCrudController.php
+++ b/app/Http/Controllers/Admin/MonsterCrudController.php
@@ -399,6 +399,7 @@ class MonsterCrudController extends CrudController
                 'type'        => 'select2_ajax',
                 'label'       => 'S2 Ajax',
                 'placeholder' => 'Pick an article',
+                'method'      => 'POST',
             ],
             url('api/article-search'), // the ajax route
             function ($value) { // if the filter is active
@@ -1049,6 +1050,7 @@ class MonsterCrudController extends CrudController
                 'attribute'            => 'title', // foreign key attribute that is shown to user
                 'model'                => "Backpack\NewsCRUD\app\Models\Article", // foreign key model
                 'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
+                'method'               => 'POST', // route method, either GET or POST
                 'placeholder'          => 'Select an article', // placeholder for the select
                 'minimum_input_length' => 2, // minimum characters to type before querying results
                 'tab'                  => 'Selects',
@@ -1102,6 +1104,7 @@ class MonsterCrudController extends CrudController
                 'attribute'            => 'title', // foreign key attribute that is shown to user
                 'model'                => "Backpack\NewsCRUD\app\Models\Article", // foreign key model
                 'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
+                'method'               => 'POST', // route method, either GET or POST
                 'placeholder'          => 'Select one or more articles', // placeholder for the select
                 'minimum_input_length' => 2, // minimum characters to type before querying results
                 'pivot'                => true, // on create&update, do you need to add/delete pivot table entries?

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -6,8 +6,8 @@
 // This route file is loaded automatically by Backpack\Base.
 // Routes you generate using Backpack\Generators will be placed here.
 
-Route::get('api/article', 'App\Http\Controllers\Api\ArticleController@index');
-Route::get('api/article-search', 'App\Http\Controllers\Api\ArticleController@search');
+Route::post('api/article', 'App\Http\Controllers\Api\ArticleController@index');
+Route::post('api/article-search', 'App\Http\Controllers\Api\ArticleController@search');
 
 Route::group([
     'prefix'     => config('backpack.base.route_prefix', 'admin'),


### PR DESCRIPTION
This is related with https://github.com/Laravel-Backpack/docs/pull/361.

Since demo is our best example, should we also move from using 'GET' to 'POST' on API calls?

Also, should we also add an example of `include_all_form_fields` usage?