### PR TITLE
Added `switch` field example

### DIFF
--- a/app/Http/Controllers/Admin/FluentMonsterCrudController.php
+++ b/app/Http/Controllers/Admin/FluentMonsterCrudController.php
@@ -173,7 +173,9 @@ class FluentMonsterCrudController extends CrudController
             2 => 'Other',
         ])->inline(true)->tab('Simple');
 
-        CRUD::field('checkbox')->type('checkbox')->label('I have not read the termins and conditions and I never will (checkbox)')->tab('Simple');
+        CRUD::field('checkbox')->type('checkbox')->label('I have not read the terms and conditions and I never will (checkbox)')->tab('Simple');
+
+        CRUD::field('switch')->type('switch')->label('I have not read the terms and conditions and I never will (switch)')->tab('Simple')->fake(true);
 
         CRUD::field('hidden')->type('hidden')->default('hidden value')->tab('Simple');
 

--- a/app/Http/Controllers/Admin/MonsterCrudController.php
+++ b/app/Http/Controllers/Admin/MonsterCrudController.php
@@ -518,6 +518,13 @@ class MonsterCrudController extends CrudController
                 'type'  => 'checkbox',
                 'tab'   => 'Simple',
             ],
+            [   // Switch
+                'name'  => 'switch',
+                'label' => 'I have not read the terms and conditions and I never will (switch)'.backpack_pro_badge(),
+                'type'  => 'switch',
+                'tab'   => 'Simple',
+                'fake'  => true,
+            ],
             [   // Hidden
                 'name'    => 'hidden',
                 'type'    => 'hidden',

--- a/app/Http/Controllers/Admin/MonsterCrudController.php
+++ b/app/Http/Controllers/Admin/MonsterCrudController.php
@@ -520,7 +520,7 @@ class MonsterCrudController extends CrudController
             ],
             [   // Switch
                 'name'  => 'switch',
-                'label' => 'I have not read the terms and conditions and I never will (switch)'.backpack_pro_badge(),
+                'label' => 'I have not read the terms and conditions and I never will (switch)'.backpack_free_badge(),
                 'type'  => 'switch',
                 'tab'   => 'Simple',
                 'fake'  => true,


### PR DESCRIPTION
As requested on https://github.com/Laravel-Backpack/demo/issues/413.

This adds the `switch` field next to the checkbox `field`.

<img width="434" alt="image" src="https://user-images.githubusercontent.com/1838187/180641043-71348e8c-6b5e-4730-aba4-214e104ead7f.png">
