### PR TITLE
Fixed PRO badge tab index

### DIFF
--- a/app/Http/Controllers/Admin/CaveCrudController.php
+++ b/app/Http/Controllers/Admin/CaveCrudController.php
@@ -58,7 +58,7 @@ class CaveCrudController extends CrudController
 
         CRUD::field('name');
         CRUD::field('monster')
-            ->label('Monster <span class="badge badge-pill badge-warning">New</span>')
+            ->label('Monster '.backpack_new_badge())
             ->subfields(self::getMonsterSubfields())
             ->hint('<small class="float-right">Define the related Monster over a <code>hasOne</code> relationship (1-1).</small>');
     }

--- a/app/Http/Controllers/Admin/FluentMonsterCrudController.php
+++ b/app/Http/Controllers/Admin/FluentMonsterCrudController.php
@@ -284,7 +284,7 @@ class FluentMonsterCrudController extends CrudController
 
         CRUD::field('icon_id')
                 ->type('relationship')
-                ->label('Relationship (1-n with InlineCreate; no AJAX) <span class="badge badge-warning">New in 4.1</span>')
+                ->label('Relationship (1-n with InlineCreate; no AJAX)'.backpack_new_badge('New in 4.1'))
                 // ->entity('icon')
                 ->attribute('name')
                 // ->data_source(backpack_url('monster/fetch/icon'))
@@ -331,7 +331,7 @@ class FluentMonsterCrudController extends CrudController
 
         CRUD::field('products')
                 ->type('relationship')
-                ->label('Relationship (n-n with InlineCreate; Fetch using AJAX) <span class="badge badge-warning">New in 4.1</span>')
+                ->label('Relationship (n-n with InlineCreate; Fetch using AJAX)'.backpack_new_badge('New in 4.1'))
                 ->entity('products')
                 // ->attribute('name')
                 ->ajax(true)

--- a/app/Http/Controllers/Admin/HeroCrudController.php
+++ b/app/Http/Controllers/Admin/HeroCrudController.php
@@ -59,7 +59,7 @@ class HeroCrudController extends CrudController
 
         CRUD::field('name');
         CRUD::field('stories')
-            ->label('Stories <span class="badge badge-pill badge-warning">New</span>')
+            ->label('Stories'.backpack_new_badge())
             ->subfields(self::getMonsterSubfields())
             ->hint('<small class="float-right">Select the related Story over a <code>belongsToMany</code> relationship (n-n) with extra pivot fields.</small>');
     }

--- a/app/Http/Controllers/Admin/MonsterCrudController.php
+++ b/app/Http/Controllers/Admin/MonsterCrudController.php
@@ -706,7 +706,7 @@ class MonsterCrudController extends CrudController
             ],
             [
                 'name'      => 'wish',
-                'label'     => 'HasOne (1-1) <small>+ subfields</small> <span class="badge badge-pill badge-warning mr-4">New</span>',
+                'label'     => 'HasOne (1-1) <small>+ subfields</small>'.backpack_new_badge(),
                 'subfields' => [
                     [
                         'name' => 'country',
@@ -725,7 +725,7 @@ class MonsterCrudController extends CrudController
             ],
             [
                 'name'      => 'postalboxes',
-                'label'     => 'HasMany (1-n) <small>+ subfields</small> <span class="badge badge-pill badge-warning mr-4">New</span>',
+                'label'     => 'HasMany (1-n) <small>+ subfields</small>'.backpack_new_badge(),
                 'subfields' => [
                     [
                         'name' => 'postal_name',
@@ -739,7 +739,7 @@ class MonsterCrudController extends CrudController
             ],
             [
                 'name'    => 'dummyproducts',
-                'label'   => 'BelongsToMany (n-n) <small>+ subfields for pivot table</small> <span class="badge badge-pill badge-warning mr-4">New</span>',
+                'label'   => 'BelongsToMany (n-n) <small>+ subfields for pivot table</small>'.backpack_new_badge(),
                 'wrapper' => [
                     'class' => 'form-group col-md-4',
                 ],
@@ -772,7 +772,7 @@ class MonsterCrudController extends CrudController
             ],
             [
                 'name'    => 'sentiment.text',
-                'label'   => 'MorphOne (1-1 polymorphic) <small>towards an attribute</small> <span class="badge badge-pill badge-warning mr-4">New</span>',
+                'label'   => 'MorphOne (1-1 polymorphic) <small>towards an attribute</small>'.backpack_new_badge(),
                 'type'    => 'relationship',
                 'wrapper' => [
                     'class' => 'form-group col-md-6',
@@ -781,7 +781,7 @@ class MonsterCrudController extends CrudController
             ],
             [
                 'name'    => 'sentiment.user',
-                'label'   => 'MorphOne (1-1 polymorphic) <small>towards a relation</small> <span class="badge badge-pill badge-warning mr-4">New</span>',
+                'label'   => 'MorphOne (1-1 polymorphic) <small>towards a relation</small>'.backpack_new_badge(),
                 'wrapper' => [
                     'class' => 'form-group col-md-6',
                 ],
@@ -789,7 +789,7 @@ class MonsterCrudController extends CrudController
             ],
             [
                 'name'    => 'universes',
-                'label'   => 'MorphMany (1-n) <span class="badge badge-pill badge-warning mr-4">New</span>',
+                'label'   => 'MorphMany (1-n)'.backpack_new_badge(),
                 'wrapper' => [
                     'class' => 'form-group col-md-6',
                 ],
@@ -797,7 +797,7 @@ class MonsterCrudController extends CrudController
             ],
             [
                 'name'    => 'bills',
-                'label'   => 'MorphToMany (n-n) <span class="badge badge-pill badge-warning mr-4">New</span>',
+                'label'   => 'MorphToMany (n-n)'.backpack_new_badge(),
                 'wrapper' => [
                     'class' => 'form-group col-md-6',
                 ],
@@ -817,7 +817,7 @@ class MonsterCrudController extends CrudController
 
             [
                 'name'    => 'ball',
-                'label'   => 'MorphOne (1-1 polymorphic) <small>+ subfields</small> <span class="badge badge-pill badge-warning mr-4">New</span>',
+                'label'   => 'MorphOne (1-1 polymorphic) <small>+ subfields</small>'.backpack_new_badge(),
                 'wrapper' => [
                     'class' => 'form-group col-md-4',
                 ],
@@ -842,7 +842,7 @@ class MonsterCrudController extends CrudController
             ],
             [
                 'name'    => 'stars',
-                'label'   => 'MorphMany (1-n) <small>+ subfields</small> <span class="badge badge-pill badge-warning mr-4">New</span>',
+                'label'   => 'MorphMany (1-n) <small>+ subfields</small>'.backpack_new_badge(),
                 'wrapper' => [
                     'class' => 'form-group col-md-4',
                 ],
@@ -857,7 +857,7 @@ class MonsterCrudController extends CrudController
             ],
             [
                 'name'    => 'recommends',
-                'label'   => 'MorphToMany (n-n) <small>+ subfields for pivot table</small> <span class="badge badge-pill badge-warning mr-4">New</span>',
+                'label'   => 'MorphToMany (n-n) <small>+ subfields for pivot table</small>'.backpack_new_badge(),
                 'wrapper' => [
                     'class' => 'form-group col-md-4',
                 ],

--- a/app/Http/Controllers/Admin/StoryCrudController.php
+++ b/app/Http/Controllers/Admin/StoryCrudController.php
@@ -59,7 +59,7 @@ class StoryCrudController extends CrudController
 
         CRUD::field('name');
         CRUD::field('monsters')
-            ->label('Monsters <span class="badge badge-pill badge-warning">New</span>')
+            ->label('Monsters'.backpack_new_badge())
             ->subfields(self::getMonsterSubfields())
             ->hint('<small class="float-right">Create/update/delete related Monsters over a <code>hasMany</code> relationship (1-n).</small>');
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -10,7 +10,7 @@ if (!function_exists('backpack_pro_badge')) {
      */
     function backpack_pro_badge(string $string = 'PRO')
     {
-        return '<a href="https://backpackforlaravel.com/pricing" target="_blank" class="badge badge-pill badge-primary ml-2 mr-2">'.$string.'</a>';
+        return '<a href="https://backpackforlaravel.com/pricing" target="_blank" class="badge badge-pill badge-primary ml-2 mr-2" tabindex="-1">'.$string.'</a>';
     }
 }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

While using TAB there was a "stop" in each `PRO` badge;

1)
<img width="584" alt="image" src="https://user-images.githubusercontent.com/1838187/180654002-1910c939-d524-4b71-b257-a4dff03998c9.png">

2)
<img width="584" alt="image" src="https://user-images.githubusercontent.com/1838187/180654012-cf93e36d-a3ca-44c6-9791-ae6e527a3f55.png">

3)
<img width="587" alt="image" src="https://user-images.githubusercontent.com/1838187/180654014-c75901f5-0647-4213-81e5-ff9e96e78377.png">


### AFTER - What is happening after this PR?

By adding `tabindex="-1"` to the DOM element, it no longer stops there.

---

While fixing it, I noticed there was a `backpack_new_badge()` that was not being used, so I replaced all the code with it.
