### PR TITLE
Added a repeatable + translatable + fake field to Products

### DIFF
--- a/app/Http/Controllers/Admin/ProductCrudController.php
+++ b/app/Http/Controllers/Admin/ProductCrudController.php
@@ -100,19 +100,35 @@ class ProductCrudController extends CrudController
             'tab' => 'Texts',
         ]);
 
-        CRUD::addField([ // Table
-            'name'            => 'extra_features',
-            'label'           => 'Extra Features',
-            'type'            => 'table',
-            'entity_singular' => 'extra feature', // used on the "Add X" button
-            'columns'         => [
-                'name' => 'Feature',
-                'desc' => 'Value',
-            ],
+        // Fake repeatable with translations
+        CRUD::addField([ // Extra Features
+            'name' => 'extra_features',
+            'label' => 'Extra Features',
+            'type' => 'repeatable',
+            'tab' => 'Texts',
+            'store_in' => 'extras',
             'fake' => true,
-            'max'  => 25, // maximum rows allowed in the table
-            'min'  => 0, // minimum rows allowed in the table
-            'tab'  => 'Texts',
+            'subfields' => [
+                [
+                    'name' => 'feature',
+                    'wrapper' => [
+                        'class' => 'col-md-3',
+                    ],
+                ],
+                [
+                    'name' => 'value',
+                    'wrapper' => [
+                        'class' => 'col-md-6',
+                    ],
+                ],
+                [
+                    'name' => 'quantity',
+                    'type' => 'number',
+                    'wrapper' => [
+                        'class' => 'col-md-3',
+                    ],
+                ],
+            ],
         ]);
 
         CRUD::addField([  // Select2

--- a/app/Http/Controllers/Admin/ProductCrudController.php
+++ b/app/Http/Controllers/Admin/ProductCrudController.php
@@ -102,28 +102,28 @@ class ProductCrudController extends CrudController
 
         // Fake repeatable with translations
         CRUD::addField([ // Extra Features
-            'name' => 'extra_features',
-            'label' => 'Extra Features',
-            'type' => 'repeatable',
-            'tab' => 'Texts',
-            'store_in' => 'extras',
-            'fake' => true,
+            'name'      => 'extra_features',
+            'label'     => 'Extra Features',
+            'type'      => 'repeatable',
+            'tab'       => 'Texts',
+            'store_in'  => 'extras',
+            'fake'      => true,
             'subfields' => [
                 [
-                    'name' => 'feature',
+                    'name'    => 'feature',
                     'wrapper' => [
                         'class' => 'col-md-3',
                     ],
                 ],
                 [
-                    'name' => 'value',
+                    'name'    => 'value',
                     'wrapper' => [
                         'class' => 'col-md-6',
                     ],
                 ],
                 [
-                    'name' => 'quantity',
-                    'type' => 'number',
+                    'name'    => 'quantity',
+                    'type'    => 'number',
                     'wrapper' => [
                         'class' => 'col-md-3',
                     ],


### PR DESCRIPTION
## WHY

This is part of https://github.com/Laravel-Backpack/PRO/pull/76.

### AFTER - What is happening after this PR?

This adds a repeatable field that is both Fake and Translatable.

<img width="994" alt="image" src="https://user-images.githubusercontent.com/1838187/184248170-b42a1561-5764-4c11-a2e1-d8d28855da85.png">
