### PR TITLE
move address_google field definition

### DIFF
--- a/app/Http/Controllers/Admin/MonsterCrudController.php
+++ b/app/Http/Controllers/Admin/MonsterCrudController.php
@@ -630,7 +630,7 @@ class MonsterCrudController extends CrudController
         if (env('GOOGLE_PLACES_KEY')) {
             $fields[] = [   // Address_google
                 'name'          => 'address_google',
-                'label'         => 'Address_google ' . backpack_pro_badge(),
+                'label'         => 'Address_google '.backpack_pro_badge(),
                 'type'          => 'address_google',
                 'fake'          => true,
                 'store_as_json' => true,

--- a/app/Http/Controllers/Admin/MonsterCrudController.php
+++ b/app/Http/Controllers/Admin/MonsterCrudController.php
@@ -263,17 +263,6 @@ class MonsterCrudController extends CrudController
         $this->crud->addFields(static::getFieldsArrayForWysiwygEditorsTab());
         $this->crud->addFields(static::getFieldsArrayForMiscellaneousTab());
 
-        if (env('GOOGLE_PLACES_KEY')) {
-            $this->crud->addField([   // Address_google
-                'name'          => 'address_google',
-                'label'         => 'Address_google '.backpack_pro_badge(),
-                'type'          => 'address_google',
-                'fake'          => true,
-                'store_as_json' => true,
-                'tab'           => 'Time and space',
-            ]);
-        }
-
         // if you want to test removeField, uncomment the following line
         // $this->crud->removeField('url');
     }
@@ -540,7 +529,7 @@ class MonsterCrudController extends CrudController
         // DATE, TIME AND SPACE tab
         // -----------------
 
-        return [
+        $fields = [
             [   // Time
                 'name'              => 'time',
                 'label'             => 'Time'.backpack_free_badge(),
@@ -637,6 +626,19 @@ class MonsterCrudController extends CrudController
                 'tab'           => 'Time and space',
             ],
         ];
+
+        if (env('GOOGLE_PLACES_KEY')) {
+            $fields[] = [   // Address_google
+                'name'          => 'address_google',
+                'label'         => 'Address_google ' . backpack_pro_badge(),
+                'type'          => 'address_google',
+                'fake'          => true,
+                'store_as_json' => true,
+                'tab'           => 'Time and space',
+            ];
+        }
+
+        return $fields;
     }
 
     public static function getFieldsArrayForRelationshipsTab()


### PR DESCRIPTION
Notice this points to https://github.com/Laravel-Backpack/demo/pull/430

## WHY

### BEFORE - What was wrong? What was happening before this PR?

We were loading all fields as column, but not `address_google` because that was manually added in `setupCreateOperation()`.

### AFTER - What is happening after this PR?

`address_google` gets loaded both as a field (in Monster CRUD) and as a column (in ColumnMonster CRUD).


## HOW

### How did you achieve that, in technical terms?

I moved the `address_google` field definition to the `getFieldsArrayForTimeAndSpaceTab()` method.


### Is it a breaking change or non-breaking change?

Non-breaking.


### How can we test the before & after?

No need.
