### PR TITLE
Remove fields from fillable that are not part of the model table

### DIFF
--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -36,6 +36,10 @@ class Story extends Model
     public function heroes()
     {
         return $this->belongsToMany(\App\Models\Hero::class, 'monsters')
-                    ->withPivot((new \App\Models\Monster())->getFillable());
+                    ->withPivot(array_filter((new \App\Models\Monster())->getFillable(), function($item) {
+                        // fields that are on fillable but are not part of model table
+                        $columnsToRemove = ['fake-text', 'fake-switch', 'fake-select', 'fake-checkbox', 'editable_checkbox'];
+                        return !in_array($item, $columnsToRemove);
+                    }));
     }
 }

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -36,9 +36,10 @@ class Story extends Model
     public function heroes()
     {
         return $this->belongsToMany(\App\Models\Hero::class, 'monsters')
-                    ->withPivot(array_filter((new \App\Models\Monster())->getFillable(), function($item) {
+                    ->withPivot(array_filter((new \App\Models\Monster())->getFillable(), function ($item) {
                         // fields that are on fillable but are not part of model table
                         $columnsToRemove = ['fake-text', 'fake-switch', 'fake-select', 'fake-checkbox', 'editable_checkbox'];
+
                         return !in_array($item, $columnsToRemove);
                     }));
     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/demo/issues/457

We introduced some fields as `fillable` in `Monster` model, but they are not columns in `monsters` table. 

When getting the relation we attempted to get those fields as part of the pivot relation and it would break the list page.

### AFTER - What is happening after this PR?

It works again.


## HOW

### How did you achieve that, in technical terms?

Excluded fields from fillable that are not part o the model table. 

### Is it a breaking change or non-breaking change?

Non.

