### PR TITLE
remove last algolia field mentions

### DIFF
--- a/app/Http/Controllers/Admin/DummyCrudController.php
+++ b/app/Http/Controllers/Admin/DummyCrudController.php
@@ -150,7 +150,6 @@ class DummyCrudController extends CrudController
         // some fields do not make sense, or do not work inside repeatable, so let's exclude them
         $excludedFieldTypes = [
             'address', // TODO
-            'address_algolia', // TODO
             'address_google', // TODO
             'checklist_dependency', // only available in PermissionManager package
             // 'custom_html', // this works (of course), it's only used for heading, but the page looks better without them

--- a/app/Http/Controllers/Admin/FluentMonsterCrudController.php
+++ b/app/Http/Controllers/Admin/FluentMonsterCrudController.php
@@ -240,12 +240,6 @@ class FluentMonsterCrudController extends CrudController
             ])
             ->tab('Time and space');
 
-        CRUD::field('address_algolia')
-            ->type('address')
-            ->label('Address (Algolia Places search)')
-            ->store_as_json(true)
-            ->tab('Time and space');
-
         // -----------------
         // SELECTS tab
         // -----------------

--- a/public/assets/js/monster/fields.js
+++ b/public/assets/js/monster/fields.js
@@ -40,7 +40,6 @@ var monsterFields = [
     'switch', // switch
     // view
     'week', // week
-    'address_algolia', 'address_algolia_string', // address_algolia PRO
     // address_google PRO
     'browse', // browse PRO
     'browse_multiple', // browse_multiple PRO


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We still have the `address_algolia` field used or mentioned in some places.

### AFTER - What is happening after this PR?

No longer. We decided to remove the field from Backpack v6, since the API has been sunset for a while now.
