### PR TITLE
Menu that supports both vertical and horizontal layouts

### DIFF
--- a/config/backpack/base.php
+++ b/config/backpack/base.php
@@ -12,7 +12,7 @@ return [
     // and choosing that view_namespace instead of the default one. Backpack will load a file from there
     // if it exists, otherwise it will load it from the default namespace ("backpack::").
 
-    'view_namespace' => 'backpack.theme-coreuiv2::',
+    'view_namespace' => 'backpack.theme-tabler::',
 
     // EXAMPLE: if you create a new folder in resources/views/vendor/myname/mypackage,
     // your namespace would be the one below. IMPORTANT: in this case the namespace ends with a dot.

--- a/resources/views/vendor/backpack/theme-coreuiv4/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/theme-coreuiv4/inc/sidebar_content.blade.php
@@ -1,5 +1,8 @@
-<li class="nav-item"><a class="nav-link" href="{{ backpack_url('dashboard') }}"><i class="nav-icon la la-dashboard"></i>
-        <span>{{ trans('backpack::base.dashboard') }}</span></a></li>
+<li class="nav-item">
+    <a class="nav-link" href="{{ backpack_url('dashboard') }}">
+        <i class="nav-icon la la-dashboard"></i> <span>{{ trans('backpack::base.dashboard') }}</span>
+    </a>
+</li>
 
 @includeWhen(class_exists(\Backpack\DevTools\DevToolsServiceProvider::class), 'backpack.devtools::buttons.sidebar_item')
 

--- a/resources/views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php
@@ -6,7 +6,7 @@
 
 @includeWhen(class_exists(\Backpack\DevTools\DevToolsServiceProvider::class), 'backpack.devtools::buttons.sidebar_item')
 
-@if(backpack_theme_config('layout.menu') !== 'horizontal' && backpack_theme_config('layout.menu') !== 'horizontal-overlap')
+@if(!\Backpack\ThemeTabler\ThemeOptions::isHorizontalLayout())
     <li class="nav-separator">First-Party Addons</li>
 @endif
 
@@ -74,7 +74,7 @@
     </div>
 </li>
 
-@if(backpack_theme_config('layout.menu') !== 'horizontal' && backpack_theme_config('layout.menu') !== 'horizontal-overlap')
+@if(!\Backpack\ThemeTabler\ThemeOptions::isHorizontalLayout())
 <li class="nav-separator">Example CRUDs</li>
 @endif
 

--- a/resources/views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php
@@ -1,6 +1,6 @@
 <li class="nav-item">
     <a class="nav-link" href="{{ backpack_url('dashboard') }}">
-        <i class="nav-icon fs-2 me-2 la la-dashboard"></i> <span>{{ trans('backpack::base.dashboard') }}</span>
+        <i class="nav-icon la la-dashboard"></i> <span>{{ trans('backpack::base.dashboard') }}</span>
     </a>
 </li>
 
@@ -9,110 +9,145 @@
 <li class="nav-separator">First-Party Addons</li>
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true"><i
-            class="nav-icon fs-2 me-2 la la-newspaper-o"></i> News</a>
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+        <i class="nav-icon la la-newspaper-o"></i>News
+    </a>
     <div class="dropdown-menu" data-bs-popper="static">
-        <a class="dropdown-item" href="{{ backpack_url('article') }}"><i
-                class="nav-icon fs-2 me-2 la la-newspaper-o"></i> <span>Articles</span></a>
-        <a class="dropdown-item" href="{{ backpack_url('category') }}"><i class="nav-icon fs-2 me-2 la la-list"></i>
-            <span>Categories</span></a>
-        <a class="dropdown-item" href="{{ backpack_url('tag') }}"><i class="nav-icon fs-2 me-2 la la-tag"></i>
-            <span>Tags</span></a>
+        <a class="dropdown-item" href="{{ backpack_url('article') }}">
+            <i class="nav-icon la la-newspaper-o"></i>Articles
+        </a>
+        <a class="dropdown-item" href="{{ backpack_url('category') }}">
+            <i class="nav-icon la la-list"></i>Categories
+        </a>
+        <a class="dropdown-item" href="{{ backpack_url('tag') }}">
+            <i class="nav-icon la la-tag"></i>Tags
+        </a>
     </div>
 </li>
 
-<li class="nav-item"><a class="nav-link" href="{{ backpack_url('page') }}"><i
-            class="nav-icon fs-2 me-2 la la-file-o"></i> <span>Pages</span></a></li>
-<li class="nav-item"><a class="nav-link" href="{{ backpack_url('menu-item') }}"><i
-            class="nav-icon fs-2 me-2 la la-list"></i> <span>Menu</span></a></li>
+<li class="nav-item"><a class="nav-link" href="{{ backpack_url('page') }}">
+        <i class="nav-icon la la-file-o"></i> Pages
+    </a>
+</li>
+<li class="nav-item"><a class="nav-link" href="{{ backpack_url('menu-item') }}">
+        <i class="nav-icon la la-list"></i>Menu
+    </a>
+</li>
 
 <!-- Users, Roles Permissions -->
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true"><i
-            class="nav-icon fs-2 me-2 la la-group"></i> Authentication</a>
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+        <i class="nav-icon la la-group"></i> Authentication
+    </a>
     <div class="dropdown-menu" data-bs-popper="static">
-        <a class="dropdown-item" href="{{ backpack_url('user') }}"><i class="nav-icon fs-2 me-2 la la-user"></i>
-            <span>Users</span></a>
-        <a class="dropdown-item" href="{{ backpack_url('role') }}"><i class="nav-icon fs-2 me-2 la la-group"></i>
-            <span>Roles</span></a>
-        <a class="dropdown-item" href="{{ backpack_url('permission') }}"><i class="nav-icon fs-2 me-2 la la-key"></i>
-            <span>Permissions</span></a>
+        <a class="dropdown-item" href="{{ backpack_url('user') }}">
+            <i class="nav-icon la la-user"></i>Users
+        </a>
+        <a class="dropdown-item" href="{{ backpack_url('role') }}">
+            <i class="nav-icon la la-group"></i>Roles
+        </a>
+        <a class="dropdown-item" href="{{ backpack_url('permission') }}">
+            <i class="nav-icon la la-key"></i>Permissions
+        </a>
     </div>
 </li>
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true"><i
-            class="nav-icon fs-2 me-2 la la-cogs"></i> Advanced</a>
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+        <i class="nav-icon la la-cogs"></i> Advanced
+    </a>
     <div class="dropdown-menu" data-bs-popper="static">
-        <a class="dropdown-item" href="{{ backpack_url('elfinder') }}"><i class="nav-icon fs-2 me-2 la la-files-o"></i>
-            <span>File manager</span></a>
-        <a class="dropdown-item" href="{{ backpack_url('backup') }}"><i class="nav-icon fs-2 me-2 la la-hdd-o"></i>
-            <span>Backups</span></a>
-        <a class="dropdown-item" href="{{ backpack_url('log') }}"><i class="nav-icon fs-2 me-2 la la-terminal"></i>
-            <span>Logs</span></a>
-        <a class="dropdown-item" href="{{ backpack_url('setting') }}"><i class="nav-icon fs-2 me-2 la la-cog"></i>
-            <span>Settings</span></a>
+        <a class="dropdown-item" href="{{ backpack_url('elfinder') }}">
+            <i class="nav-icon la la-files-o"></i>File
+        </a>
+        <a class="dropdown-item" href="{{ backpack_url('backup') }}">
+            <i class="nav-icon la la-hdd-o"></i>Backups
+        </a>
+        <a class="dropdown-item" href="{{ backpack_url('log') }}">
+            <i class="nav-icon la la-terminal"></i>Logs
+        </a>
+        <a class="dropdown-item" href="{{ backpack_url('setting') }}">
+            <i class="nav-icon la la-cog"></i>Settings
+        </a>
     </div>
 </li>
 
 <li class="nav-separator">Example CRUDs</li>
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true"><i
-            class="nav-icon fs-2 me-2 la la-optin-monster"></i> Monsters & Stuff</a>
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+        <i class="nav-icon la la-optin-monster"></i> Monsters & Stuff
+    </a>
     <div class="dropdown-menu" data-bs-popper="static">
-        <a class="dropdown-item" href="{{ backpack_url('monster') }}"><i
-                class="nav-icon fs-2 me-2 la la-optin-monster"></i> <span>Monsters</span></a>
-        <a class='dropdown-item' href='{{ backpack_url('cave') }}'><i class='nav-icon la la-dungeon'></i> Caves <span
-                class="badge badge-pill bg-warning">New</span></a>
-        <a class='dropdown-item' href='{{ backpack_url('story') }}'><i class='nav-icon la la-book'></i> Stories <span
-                class="badge badge-pill bg-warning">New</span></a>
-    </div>
-</li>
-
-<li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true"><i
-            class="nav-icon fs-2 me-2 la la-question"></i> Other entities</a>
-    <div class="dropdown-menu" data-bs-popper="static">
-        <a class="dropdown-item" href="{{ backpack_url('icon') }}"><i class="nav-icon fs-2 me-2 la la-info-circle"></i>
-            <span>Icons</span></a>
-        <a class="dropdown-item" href="{{ backpack_url('product') }}"><i
-                class="nav-icon fs-2 me-2 la la-shopping-cart"></i> <span>Products</span></a>
-        <a class="dropdown-item" href="{{ backpack_url('fluent-monster') }}"><i
-                class="nav-icon fs-2 me-2 la la-pastafarianism"></i> <span>Fluent Monsters</span></a>
-        <a class="dropdown-item" href="{{ backpack_url('field-monster') }}"><i
-                class="nav-icon fs-2 me-2 la la-list-alt"></i> <span>Field Monsters</span></a>
-        <a class="dropdown-item" href="{{ backpack_url('editable-monster') }}"><i
-                class="nav-icon fs-2 me-2 la la-spell-check"></i> <span>Editable Monsters</span></a>
-        <a class="dropdown-item" href="{{ backpack_url('dummy') }}"><i class="nav-icon fs-2 me-2 la la-poo"></i>
-            <span>Dummies</span></a>
+        <a class="dropdown-item" href="{{ backpack_url('monster') }}">
+            <i class="nav-icon la la-optin-monster"></i>Monsters
+        </a>
+        <a class='dropdown-item' href='{{ backpack_url('cave') }}'>
+            <i class='nav-icon la la-dungeon'></i>Caves <span class="badge badge-pill bg-warning">New</span>
+        </a>
+        <a class='dropdown-item' href='{{ backpack_url('story') }}'>
+            <i class='nav-icon la la-book'></i>Stories <span class="badge badge-pill bg-warning">New</span>
+        </a>
     </div>
 </li>
 
 <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true">
-        <i class="nav-icon fs-2 me-2 la la-dog"></i> Pet Shop <span
-            class="badge text-light badge-pill bg-warning">New</span>
+        <i class="nav-icon la la-question"></i> Other entities
     </a>
     <div class="dropdown-menu" data-bs-popper="static">
-        <a class="dropdown-item" href='{{ backpack_url('pet-shop/about') }}'><i class='nav-icon la la-question'></i>
-            About</a>
-        <a class="dropdown-item" href='{{ backpack_url('pet-shop/invoice') }}'><i class='nav-icon la la-file-text'></i>
-            Invoices</a>
-        <a class="dropdown-item" href='{{ backpack_url('pet-shop/owner') }}'><i class='nav-icon la la-user'></i>
-            Owners</a>
-        <a class="dropdown-item" href='{{ backpack_url('pet-shop/pet') }}'><i class='nav-icon la la-dog'></i> Pets</a>
-        <a class="dropdown-item" href='{{ backpack_url('pet-shop/badge') }}'><i class='nav-icon la la-certificate'></i>
-            Badges</a>
-        <a class="dropdown-item" href='{{ backpack_url('pet-shop/skill') }}'><i class='nav-icon la la-ribbon'></i>
-            Skills</a>
-        <a class="dropdown-item" href='{{ backpack_url('pet-shop/comment') }}'><i class='nav-icon la la-comment'></i>
-            Comments</a>
+        <a class="dropdown-item" href="{{ backpack_url('icon') }}">
+            <i class="nav-icon la la-info-circle"></i>Icons
+        </a>
+        <a class="dropdown-item" href="{{ backpack_url('product') }}">
+            <i class="nav-icon la la-shopping-cart"></i> Products
+        </a>
+        <a class="dropdown-item" href="{{ backpack_url('fluent-monster') }}">
+            <i class="nav-icon la la-pastafarianism"></i> Fluent Monsters
+        </a>
+        <a class="dropdown-item" href="{{ backpack_url('field-monster') }}">
+            <i class="nav-icon la la-list-alt"></i> Field Monsters
+        </a>
+        <a class="dropdown-item" href="{{ backpack_url('editable-monster') }}">
+            <i class="nav-icon la la-spell-check"></i> Editable Monsters
+        </a>
+        <a class="dropdown-item" href="{{ backpack_url('dummy') }}">
+            <i class="nav-icon la la-poo"></i>
+            Dummies
+        </a>
+    </div>
+</li>
+
+<li class="nav-item dropdown">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+        <i class="nav-icon la la-dog"></i> Pet Shop <span class="badge text-light badge-pill bg-warning">New</span>
+    </a>
+    <div class="dropdown-menu" data-bs-popper="static">
+        <a class="dropdown-item" href='{{ backpack_url('pet-shop/about') }}'>
+            <i class='nav-icon la la-question'></i>About
+        </a>
+        <a class="dropdown-item" href='{{ backpack_url('pet-shop/invoice') }}'>
+            <i class='nav-icon la la-file-text'></i>Invoices
+        </a>
+        <a class="dropdown-item" href='{{ backpack_url('pet-shop/owner') }}'>
+            <i class='nav-icon la la-user'></i>Owners
+        </a>
+        <a class="dropdown-item" href='{{ backpack_url('pet-shop/pet') }}'>
+            <i class='nav-icon la la-dog'></i> Pets</a><a class="dropdown-item" href='{{ backpack_url('pet-shop/badge')
+}}'>
+            <i class='nav-icon la la-certificate'></i>Badges
+        </a>
+        <a class="dropdown-item" href='{{ backpack_url('pet-shop/skill') }}'>
+            <i class='nav-icon la la-ribbon'></i>Skills
+        </a>
+        <a class="dropdown-item" href='{{ backpack_url('pet-shop/comment') }}'>
+            <i class='nav-icon la la-comment'></i>Comments
+        </a>
     </div>
 </li>
 
 <li class="nav-item">
     <a class="nav-link" href="{{ backpack_url('elfinder') }}">
-        <i class="nav-icon fs-2 me-2 la la-files-o"></i> <span>{{ trans('backpack::crud.file_manager') }}</span>
+        <i class="nav-icon la la-files-o"></i> <span>{{ trans('backpack::crud.file_manager') }}</span>
     </a>
 </li>

--- a/resources/views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php
@@ -6,7 +6,7 @@
 
 @includeWhen(class_exists(\Backpack\DevTools\DevToolsServiceProvider::class), 'backpack.devtools::buttons.sidebar_item')
 
-@if(config('backpack.theme-tabler.nav_position') === 'left')
+@if(backpack_theme_config('layout.menu') !== 'horizontal')
     <li class="nav-separator">First-Party Addons</li>
 @endif
 
@@ -74,7 +74,7 @@
     </div>
 </li>
 
-@if(config('backpack.theme-tabler.nav_position') === 'left')
+@if(backpack_theme_config('layout.menu') !== 'horizontal')
 <li class="nav-separator">Example CRUDs</li>
 @endif
 

--- a/resources/views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php
@@ -11,7 +11,7 @@
 @endif
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ config('backpack.theme-tabler.nav_position') === 'left' ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ !\Backpack\ThemeTabler\ThemeOptions::isHorizontalLayout() ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
         <i class="nav-icon la la-newspaper-o"></i>News
     </a>
     <div class="dropdown-menu" data-bs-popper="static">
@@ -38,7 +38,7 @@
 
 <!-- Users, Roles Permissions -->
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ config('backpack.theme-tabler.nav_position') === 'left' ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ !\Backpack\ThemeTabler\ThemeOptions::isHorizontalLayout() ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
         <i class="nav-icon la la-group"></i> Authentication
     </a>
     <div class="dropdown-menu" data-bs-popper="static">
@@ -55,7 +55,7 @@
 </li>
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ config('backpack.theme-tabler.nav_position') === 'left' ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ !\Backpack\ThemeTabler\ThemeOptions::isHorizontalLayout() ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
         <i class="nav-icon la la-cogs"></i> Advanced
     </a>
     <div class="dropdown-menu" data-bs-popper="static">
@@ -79,7 +79,7 @@
 @endif
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ config('backpack.theme-tabler.nav_position') === 'left' ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ !\Backpack\ThemeTabler\ThemeOptions::isHorizontalLayout() ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
         <i class="nav-icon la la-optin-monster"></i> Monsters & Stuff
     </a>
     <div class="dropdown-menu" data-bs-popper="static">
@@ -96,7 +96,7 @@
 </li>
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ config('backpack.theme-tabler.nav_position') === 'left' ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ !\Backpack\ThemeTabler\ThemeOptions::isHorizontalLayout() ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
         <i class="nav-icon la la-question"></i> Other entities
     </a>
     <div class="dropdown-menu" data-bs-popper="static">
@@ -123,7 +123,7 @@
 </li>
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ config('backpack.theme-tabler.nav_position') === 'left' ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ !\Backpack\ThemeTabler\ThemeOptions::isHorizontalLayout() ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
         <i class="nav-icon la la-dog"></i> Pet Shop <span class="badge text-light badge-pill bg-warning">New</span>
     </a>
     <div class="dropdown-menu" data-bs-popper="static">

--- a/resources/views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php
@@ -6,10 +6,12 @@
 
 @includeWhen(class_exists(\Backpack\DevTools\DevToolsServiceProvider::class), 'backpack.devtools::buttons.sidebar_item')
 
-<li class="nav-separator">First-Party Addons</li>
+@if(config('backpack.theme-tabler.nav_position') === 'left')
+    <li class="nav-separator">First-Party Addons</li>
+@endif
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ config('backpack.theme-tabler.nav_position') === 'left' ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
         <i class="nav-icon la la-newspaper-o"></i>News
     </a>
     <div class="dropdown-menu" data-bs-popper="static">
@@ -36,7 +38,7 @@
 
 <!-- Users, Roles Permissions -->
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ config('backpack.theme-tabler.nav_position') === 'left' ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
         <i class="nav-icon la la-group"></i> Authentication
     </a>
     <div class="dropdown-menu" data-bs-popper="static">
@@ -53,7 +55,7 @@
 </li>
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ config('backpack.theme-tabler.nav_position') === 'left' ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
         <i class="nav-icon la la-cogs"></i> Advanced
     </a>
     <div class="dropdown-menu" data-bs-popper="static">
@@ -72,10 +74,12 @@
     </div>
 </li>
 
+@if(config('backpack.theme-tabler.nav_position') === 'left')
 <li class="nav-separator">Example CRUDs</li>
+@endif
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ config('backpack.theme-tabler.nav_position') === 'left' ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
         <i class="nav-icon la la-optin-monster"></i> Monsters & Stuff
     </a>
     <div class="dropdown-menu" data-bs-popper="static">
@@ -92,7 +96,7 @@
 </li>
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ config('backpack.theme-tabler.nav_position') === 'left' ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
         <i class="nav-icon la la-question"></i> Other entities
     </a>
     <div class="dropdown-menu" data-bs-popper="static">
@@ -119,7 +123,7 @@
 </li>
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="false" data-bs-toggle="dropdown" role="button" aria-expanded="true">
+    <a class="nav-link dropdown-toggle" href="#" data-bs-auto-close="{{ config('backpack.theme-tabler.nav_position') === 'left' ? 'false' : 'true' }}" data-bs-toggle="dropdown" role="button" aria-expanded="true">
         <i class="nav-icon la la-dog"></i> Pet Shop <span class="badge text-light badge-pill bg-warning">New</span>
     </a>
     <div class="dropdown-menu" data-bs-popper="static">
@@ -133,8 +137,7 @@
             <i class='nav-icon la la-user'></i>Owners
         </a>
         <a class="dropdown-item" href='{{ backpack_url('pet-shop/pet') }}'>
-            <i class='nav-icon la la-dog'></i> Pets</a><a class="dropdown-item" href='{{ backpack_url('pet-shop/badge')
-}}'>
+            <i class='nav-icon la la-dog'></i> Pets</a><a class="dropdown-item" href='{{ backpack_url('pet-shop/badge') }}'>
             <i class='nav-icon la la-certificate'></i>Badges
         </a>
         <a class="dropdown-item" href='{{ backpack_url('pet-shop/skill') }}'>

--- a/resources/views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php
@@ -6,7 +6,7 @@
 
 @includeWhen(class_exists(\Backpack\DevTools\DevToolsServiceProvider::class), 'backpack.devtools::buttons.sidebar_item')
 
-@if(backpack_theme_config('layout.menu') !== 'horizontal')
+@if(backpack_theme_config('layout.menu') !== 'horizontal' && backpack_theme_config('layout.menu') !== 'horizontal-overlap')
     <li class="nav-separator">First-Party Addons</li>
 @endif
 
@@ -74,7 +74,7 @@
     </div>
 </li>
 
-@if(backpack_theme_config('layout.menu') !== 'horizontal')
+@if(backpack_theme_config('layout.menu') !== 'horizontal' && backpack_theme_config('layout.menu') !== 'horizontal-overlap')
 <li class="nav-separator">Example CRUDs</li>
 @endif
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The demo didn't look very good when using the Tabler theme:
![CleanShot 2023-04-03 at 14 44 16](https://user-images.githubusercontent.com/1032474/229499848-d962dcd7-5ad8-4552-b1a6-3407ed8dda03.png)


### AFTER - What is happening after this PR?

It does, because we hide the separators from the menu, if it's horizontal.

