### PR TITLE
[v6][Bug] In login page, tab from email input does not go to input password

### DIFF
--- a/resources/views/vendor/backpack/theme-tabler/auth/login/inc/form.blade.php
+++ b/resources/views/vendor/backpack/theme-tabler/auth/login/inc/form.blade.php
@@ -3,7 +3,7 @@
     @csrf
     <div class="mb-3">
         <label class="form-label" for="{{ $username }}">{{ config('backpack.base.authentication_column_name') }}</label>
-        <input autofocus type="email" name="{{ $username }}" value="{{ old($username, 'admin@example.com') }}" id="{{ $username }}" class="form-control {{ $errors->has($username) ? 'is-invalid' : '' }}">
+        <input autofocus tabindex="1" type="email" name="{{ $username }}" value="{{ old($username, 'admin@example.com') }}" id="{{ $username }}" class="form-control {{ $errors->has($username) ? 'is-invalid' : '' }}">
         @if ($errors->has($username))
             <div class="invalid-feedback">{{ $errors->first($username) }}</div>
         @endif
@@ -17,7 +17,7 @@
                 </div>
             @endif
         </label>
-        <input type="password" name="password" id="password" class="form-control {{ $errors->has('password') ? 'is-invalid' : '' }}" value="{{ old($username) ? '' : 'admin' }}">
+        <input tabindex="2" type="password" name="password" id="password" class="form-control {{ $errors->has('password') ? 'is-invalid' : '' }}" value="{{ old($username) ? '' : 'admin' }}">
         @if ($errors->has('password'))
             <div class="invalid-feedback">{{ $errors->first('password') }}</div>
         @endif
@@ -29,6 +29,6 @@
         </label>
     </div>
     <div class="form-footer">
-        <button type="submit" class="btn btn-primary w-100">{{ trans('backpack::base.login') }}</button>
+        <button tabindex="3" type="submit" class="btn btn-primary w-100">{{ trans('backpack::base.login') }}</button>
     </div>
 </form>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Described [here](https://github.com/Laravel-Backpack/theme-tabler/issues/30).

### AFTER - What is happening after this PR?

Now you can navigate through inputs in order using tab key.


## HOW

### How did you achieve that, in technical terms?

Add tabindex to inputs.