### PR TITLE
Fix logo size across themes

### DIFF
--- a/config/backpack/ui.php
+++ b/config/backpack/ui.php
@@ -57,7 +57,7 @@ return [
     'home_link' => '',
 
     // Menu logo. You can replace this with an <img> tag if you have a logo.
-    'project_logo'   => '<img src="/assets/img/backpack_logo.png" class="project-logo" alt="Backpack for Laravel">',
+    'project_logo'   => '<img src="/assets/img/backpack_logo.png" class="project-logo" style="max-width: 150px; height: auto;" alt="Backpack for Laravel">',
 
     // Show / hide breadcrumbs on admin panel pages.
     'breadcrumbs' => true,


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The logo was huge in all themes but Tabler.

### AFTER - What is happening after this PR?

We are using inline style right in the config file for the logo.

**It will fix:**
https://github.com/Laravel-Backpack/theme-coreuiv4/issues/8
https://github.com/Laravel-Backpack/theme-coreuiv2/issues/6

**Tabler** should be updated as well with this:
https://github.com/Laravel-Backpack/theme-tabler/pull/37