### PR TITLE
Fix dropzone in production

### DIFF
--- a/app/Http/Controllers/Admin/MonsterCrudController.php
+++ b/app/Http/Controllers/Admin/MonsterCrudController.php
@@ -1607,8 +1607,8 @@ class MonsterCrudController extends CrudController
     {
         if (app('env') === 'production') {
             return response()->json(['errors' => [
-                'dropzone' => ['Uploads are disabled in production']
-                ]
+                'dropzone' => ['Uploads are disabled in production'],
+            ],
             ], 500);
         }
 

--- a/app/Http/Controllers/Admin/MonsterCrudController.php
+++ b/app/Http/Controllers/Admin/MonsterCrudController.php
@@ -1606,7 +1606,10 @@ class MonsterCrudController extends CrudController
     public function dropzoneUpload()
     {
         if (app('env') === 'production') {
-            return response()->json([]);
+            return response()->json(['errors' => [
+                'dropzone' => ['Uploads are disabled in production']
+                ]
+            ], 500);
         }
 
         return $this->traitDropzone();

--- a/app/Http/Controllers/Admin/ProductCrudController.php
+++ b/app/Http/Controllers/Admin/ProductCrudController.php
@@ -295,7 +295,10 @@ class ProductCrudController extends CrudController
     public function dropzoneUpload()
     {
         if (app('env') === 'production') {
-            return response()->json([]);
+            return response()->json(['errors' => [
+                'dropzone' => ['Uploads are disabled in production']
+                ]
+            ], 500);
         }
 
         return $this->traitDropzoneUpload();

--- a/app/Http/Controllers/Admin/ProductCrudController.php
+++ b/app/Http/Controllers/Admin/ProductCrudController.php
@@ -296,8 +296,8 @@ class ProductCrudController extends CrudController
     {
         if (app('env') === 'production') {
             return response()->json(['errors' => [
-                'dropzone' => ['Uploads are disabled in production']
-                ]
+                'dropzone' => ['Uploads are disabled in production'],
+            ],
             ], 500);
         }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in #548 

We had disabled dropzone in `ProductCrudController` but we left an instance of Dropzone "functional" in Monster. 

I decided to no use the `disabledInProduction` macro as we did in Product because we didn't disabled the other upload fields in Monster. Instead I return an error from the controller.

![image](https://github.com/Laravel-Backpack/demo/assets/7188159/9c04599f-77ab-48c8-b685-4726a3071bcc)

I added the same return in our ProductCrudController in case the user is sneaky and remove the `disabled` attribute.
