### PR TITLE
make db:fresh commant refresh basset too

### DIFF
--- a/app/Console/Commands/RefreshDb.php
+++ b/app/Console/Commands/RefreshDb.php
@@ -44,5 +44,6 @@ class RefreshDb extends Command
         Artisan::call('migrate --force');
         Artisan::call('db:seed --force');
         Artisan::call('backup:clean');
+        Artisan::call('basset:fresh');
     }
 }


### PR DESCRIPTION
Sometimes in our demo, basset URLs do not load what they're supposed to - see https://github.com/Laravel-Backpack/demo/issues/552 for more info.

I tested multiple things, and fixes it is running `php artisan basset:fresh`. So maybe we should do this after each `db:fresh`? 🤷‍♂️

My only problem with this is that... I don't understand _why_. Why does `db:fresh` break assets? And does it _really_? Because on localhost `db:fresh` does NOT break stuff for me. So... this fixes it... and applies the fix every hour... so it increases the changes that people don't see our demo broken... but... why?

![kevin-hart-crying-gif-by-team-coco](https://github.com/Laravel-Backpack/demo/assets/1032474/18442218-4078-4165-b759-7e773ebd9d42)
