### PR TITLE
Avoid symlink error on composer post install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         ],
         "post-install-cmd": [
             "Illuminate\\Foundation\\ComposerScripts::postInstall",
-            "php artisan storage:link"
+            "php artisan storage:link -q"
         ],
         "post-update-cmd": [
             "Illuminate\\Foundation\\ComposerScripts::postUpdate"


### PR DESCRIPTION
We now know we can add the `-q` quiet argument to avoid the erro 👌

![image](https://github.com/Laravel-Backpack/demo/assets/1838187/11b287cf-f9e3-48bd-a4fe-6512a804824c)

