### PR TITLE
show example button

### DIFF
--- a/app/Http/Controllers/Admin/MonsterCrudController.php
+++ b/app/Http/Controllers/Admin/MonsterCrudController.php
@@ -218,7 +218,7 @@ class MonsterCrudController extends CrudController
 
         //quickly create a button
         $this->crud->button('email')->stack('top')->view('crud::buttons.quick')->meta([
-            'access'  => 'Quick Button',
+            'access'  => true,
             'label'   => 'Quick Button',
             'icon'    => 'la la-fast-forward',
             'wrapper' => [


### PR DESCRIPTION
The button was not displayed because we didn't `allow` the `Quick Button` permission.

 I don't think it makes sense that permission, so I just made it `true`. It's just a button to the docs.

