### PR TITLE
Avoid sql enums on demo

### DIFF
--- a/database/migrations/2015_08_04_130520_create_articles_table.php
+++ b/database/migrations/2015_08_04_130520_create_articles_table.php
@@ -19,7 +19,7 @@ class CreateArticlesTable extends Migration
             $table->string('slug')->default('');
             $table->text('content');
             $table->string('image')->nullable();
-            $table->enum('status', ['PUBLISHED', 'DRAFT'])->default('PUBLISHED');
+            $table->string('status')->default('PUBLISHED');
             $table->date('date');
             $table->boolean('featured')->default(0);
             $table->timestamps();


### PR DESCRIPTION
Fix for a very old issue #68.

We can avoid using enums on demo, the change of the field to a `select2_from_array` on NewsCRUD package was already done long ago.