### PR TITLE
Fix for an unreleased feature

### DIFF
--- a/app/Http/Controllers/Admin/UserCrudController.php
+++ b/app/Http/Controllers/Admin/UserCrudController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
-use Backpack\ActivityLog\Models\ActivityLog;
+use Backpack\ActivityLog\Enums\ActivityLogEnum;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
 use Backpack\PermissionManager\app\Http\Controllers\UserCrudController as OriginalUserCrudController;
 
@@ -13,7 +13,7 @@ class UserCrudController extends OriginalUserCrudController
 
     public function setupListOperation()
     {
-        CRUD::set('activity-log.options', ActivityLog::CAUSER);
+        CRUD::set('activity-log.options', ActivityLogEnum::CAUSER);
 
         parent::setupListOperation();
     }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^11.0",
-        "backpack/activity-log": "^2.0",
+        "backpack/activity-log": "^2.0.3",
         "backpack/crud": "^6.7",
         "backpack/pro": "^2.0",
         "backpack/filemanager": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "09b9a30aea0b6cc7e75c5d791b557d56",
+    "content-hash": "7e9b5c8306eff3fd6c7b606726236cf8",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -157,16 +157,16 @@
         },
         {
             "name": "backpack/activity-log",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Backpack/activity-log.git",
-                "reference": "42f7da84cde10fa211859e637a9d6d398c1ca55a"
+                "reference": "d190e7f19a3dbcf71ba8d3cae17c8a450b49bc02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Backpack/activity-log/zipball/42f7da84cde10fa211859e637a9d6d398c1ca55a",
-                "reference": "42f7da84cde10fa211859e637a9d6d398c1ca55a",
+                "url": "https://api.github.com/repos/Laravel-Backpack/activity-log/zipball/d190e7f19a3dbcf71ba8d3cae17c8a450b49bc02",
+                "reference": "d190e7f19a3dbcf71ba8d3cae17c8a450b49bc02",
                 "shasum": ""
             },
             "require": {
@@ -217,9 +217,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Laravel-Backpack/activity-log/issues",
-                "source": "https://github.com/Laravel-Backpack/activity-log/tree/2.0.2"
+                "source": "https://github.com/Laravel-Backpack/activity-log/tree/2.0.3"
             },
-            "time": "2024-02-13T11:48:43+00:00"
+            "time": "2024-04-07T23:31:16+00:00"
         },
         {
             "name": "backpack/backupmanager",


### PR DESCRIPTION
By merging https://github.com/Laravel-Backpack/activity-log/pull/30/files, we changed the way `activity-log.options` works.
It's not a breaking change because the feature was not documented.

This aligns demo with the proper way the feature works.

Before this PR, User CRUD Activity buttons were not working.
Now it is.