### PR TITLE
Bug Fix

### DIFF
--- a/resources/views/vendor/backpack/theme-tabler/dashboard.blade.php
+++ b/resources/views/vendor/backpack/theme-tabler/dashboard.blade.php
@@ -28,7 +28,7 @@
     $userCount = App\User::count();
     $articleCount = \Backpack\NewsCRUD\app\Models\Article::count();
     $lastArticle = \Backpack\NewsCRUD\app\Models\Article::orderBy('date', 'DESC')->first();
-    $lastArticleDaysAgo = \Carbon\Carbon::parse($lastArticle->date)->diffInDays(\Carbon\Carbon::today());
+    $lastArticleDaysAgo = \Carbon\Carbon::parse($lastArticle->date ?? "now")->diffInDays(\Carbon\Carbon::today());
 
      // notice we use Widget::add() to add widgets to a certain group
     Widget::add()->to('before_content')->type('div')->class('row mt-3')->content([

--- a/resources/views/vendor/backpack/theme-tabler/dashboard.blade.php
+++ b/resources/views/vendor/backpack/theme-tabler/dashboard.blade.php
@@ -28,7 +28,7 @@
     $userCount = App\User::count();
     $articleCount = \Backpack\NewsCRUD\app\Models\Article::count();
     $lastArticle = \Backpack\NewsCRUD\app\Models\Article::orderBy('date', 'DESC')->first();
-    $lastArticleDaysAgo = \Carbon\Carbon::parse($lastArticle->date ?? "now")->diffInDays(\Carbon\Carbon::today());
+        $lastArticleDaysAgo = $lastArticle !== null ? \Carbon\Carbon::parse($lastArticle->date)->diffInDays(\Carbon\Carbon::today()).' days' : 'No articles';
 
      // notice we use Widget::add() to add widgets to a certain group
     Widget::add()->to('before_content')->type('div')->class('row mt-3')->content([


### PR DESCRIPTION
When there are no articles, the dashboard gives a 500 error because it is trying to get the date on a non-existent object

## WHY

### BEFORE - What was wrong? What was happening before this PR?

There was a 500 error sometimes on the Tabler dashboard

### AFTER - What is happening after this PR?

There is no more 500 error


## HOW

### How did you achieve that, in technical terms?

When you are trying to get the date of the most recently published article, if there is none I just get today



### Is it a breaking change or non-breaking change?

Non-breaking


### How can we test the before & after?

Have a refreshed database and load the dashboard with the Tabler theme
