### PR TITLE
Removes the truncates and reduce the amount of seeded data

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -35,37 +35,26 @@ class DatabaseSeeder extends Seeder
         ]);
 
         // Faker factories
-        Recommend::truncate();
         Recommend::factory()->count(30)->create();
 
-        PostalBoxer::truncate();
         PostalBoxer::factory()->count(30)->create();
 
-        Bill::truncate();
         Bill::factory()->count(30)->create();
 
-        Tag::truncate();
         Tag::factory()->count(21)->create();
 
-        Category::truncate();
         Category::factory()->count(40)->create();
 
-        Article::truncate();
         Article::factory()->count(1031)->create();
 
-        Product::truncate();
         Product::factory()->count(210)->create();
 
-        Monster::truncate();
         Monster::factory()->count(140)->create();
 
-        Page::truncate();
         Page::factory()->count(16)->create();
 
-        MenuItem::truncate();
         MenuItem::factory()->count(7)->create();
 
-        Meeting::truncate();
         Meeting::factory()->count(50)->create();
     }
 }

--- a/database/seeders/MillionCommentsSeeder.php
+++ b/database/seeders/MillionCommentsSeeder.php
@@ -32,13 +32,13 @@ class MillionCommentsSeeder extends Seeder
         DB::disableQueryLog();
         DB::beginTransaction();
 
-        for ($i = 1; $i <= 1000; $i++) {
+        for ($i = 1; $i <= 100; $i++) {
             $body = $this->faker->text;
             $commentable = $i % 2 == 0 ? $this->owners->random() : $this->pets->random();
             $commentable_type = get_class($commentable);
             $commentable_id = $commentable->getKey();
 
-            $comments = array_fill(0, 1000, [
+            $comments = array_fill(0, 100, [
                 'body'             => $body,
                 'commentable_type' => $commentable_type,
                 'commentable_id'   => $commentable_id,


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Truncates are broken if you are using foreign keys and enforcing them. 

Seeders shouldn't truncate the tables , at most they can have a circuit breaker to don't seed in certain scenarios. 

Also reduce the seeders of 1M comments to 100k, I re-seed the database several times a day during tests and 99% of times I am not messing with those 1M records.