### PR TITLE
fix owner comments relation definition

### DIFF
--- a/app/Models/PetShop/Owner.php
+++ b/app/Models/PetShop/Owner.php
@@ -46,7 +46,7 @@ class Owner extends Model
 
     public function comments()
     {
-        return $this->morphMany(\App\Models\PetShop\Comment::class, 'commentable', null, null, 'user_id');
+        return $this->morphMany(Comment::class, 'commentable');
     }
 
     public function badges()


### PR DESCRIPTION
## WHY
fixes: https://github.com/Laravel-Backpack/demo/issues/651

`comments()` relation on `Owner` model was not properly defined. 