### PR TITLE
wrap details row text

### DIFF
--- a/resources/views/vendor/backpack/crud/details_row/monster.blade.php
+++ b/resources/views/vendor/backpack/crud/details_row/monster.blade.php
@@ -1,5 +1,5 @@
 <div class="m-t-10 m-b-10 p-l-10 p-r-10 p-t-10 p-b-10">
-	<div class="row">
+	<div class="row text-wrap">
 		<div class="col-md-12">
 			<small>Use the <span class="label label-default">details_row</span> functionality to show more information about the entry, when that information does not fit inside the table column.</small><br><br>
 			<strong>Text:</strong> {{ $entry->text }} <br>


### PR DESCRIPTION
## WHY

fixes https://github.com/Laravel-Backpack/demo/issues/656

### BEFORE - What was wrong? What was happening before this PR?

Text inside the details row would force the table to expand.

### AFTER - What is happening after this PR?

No more, it will respect the container width and break lines when needed.


## HOW

### How did you achieve that, in technical terms?

Adding `text-wrap` bootstrap class to the details row.



