### PR TITLE
Link v7 components page to the docs.

### DIFF
--- a/resources/views/admin/new-in-v7.blade.php
+++ b/resources/views/admin/new-in-v7.blade.php
@@ -44,7 +44,7 @@
     <div class="col-auto ms-auto d-print-none">
         <div class="btn-list">
             <span class="d-none d-sm-inline">
-                <a href="#" class="btn btn-primary"> See docs </a> <!-- TODO: link to final docs -->
+                <a target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/crud-chips" class="btn btn-primary"> See docs </a> <!-- TODO: link to final docs -->
             </span>
         </div>
     </div>
@@ -62,7 +62,7 @@
     <div class="col-auto ms-auto d-print-none">
         <div class="btn-list">
             <span class="d-none d-sm-inline">
-                <a href="#" class="btn btn-primary"> See docs </a> <!-- TODO: link to final docs -->
+                <a target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/base-components#datagrid-1" class="btn btn-primary"> See docs </a> <!-- TODO: link to final docs -->
             </span>
         </div>
     </div>
@@ -80,7 +80,7 @@
     <div class="col-auto ms-auto d-print-none">
         <div class="btn-list">
             <span class="d-none d-sm-inline">
-                <a href="#" class="btn btn-primary"> See docs </a> <!-- TODO: link to final docs -->
+                <a target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/base-components#datalist-1" class="btn btn-primary"> See docs </a> <!-- TODO: link to final docs -->
             </span>
         </div>
     </div>
@@ -98,7 +98,7 @@
     <div class="col-auto ms-auto d-print-none">
         <div class="btn-list">
             <span class="d-none d-sm-inline">
-                <a href="#" class="btn btn-primary"> See docs </a> <!-- TODO: link to final docs -->
+                <a target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/base-components#datatable-1" class="btn btn-primary"> See docs </a> <!-- TODO: link to final docs -->
             </span>
         </div>
     </div>
@@ -116,7 +116,7 @@
     <div class="col-auto ms-auto d-print-none">
         <div class="btn-list">
             <span class="d-none d-sm-inline">
-                <a href="#" class="btn btn-primary"> See docs </a> <!-- TODO: link to final docs -->
+                <a target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/base-components#dataform-1" class="btn btn-primary"> See docs </a> <!-- TODO: link to final docs -->
             </span>
         </div>
     </div>

--- a/resources/views/admin/partials/dataform-examples.blade.php
+++ b/resources/views/admin/partials/dataform-examples.blade.php
@@ -23,8 +23,8 @@
                             </svg>
                         </a>
                         <div class="dropdown-menu dropdown-menu-end" style="">
-                            <a class="dropdown-item" href="#">See demo code</a> <!-- TODO: link to demo code -->
-                            <a class="dropdown-item" href="#">See docs</a> <!-- TODO: link to final docs -->
+                            <a class="dropdown-item" target="_blank" href="https://github.com/Laravel-Backpack/demo/blob/next/resources/views/admin/partials/dataform-examples.blade.php">See demo code</a> <!-- TODO: link to demo code -->
+                            <a class="dropdown-item" target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/base-components#dataform-1">See docs</a> <!-- TODO: link to final docs -->
                         </div>
                     </div>
                 </div>

--- a/resources/views/admin/partials/datagrid-examples.blade.php
+++ b/resources/views/admin/partials/datagrid-examples.blade.php
@@ -24,8 +24,8 @@
                             </svg>
                         </a>
                         <div class="dropdown-menu dropdown-menu-end" style="">
-                            <a class="dropdown-item" href="#">See demo code</a> <!-- TODO: link to demo code -->
-                            <a class="dropdown-item" href="#">See docs</a> <!-- TODO: link to final docs -->
+                            <a class="dropdown-item" target="_blank" href="https://github.com/Laravel-Backpack/demo/blob/next/resources/views/admin/partials/datagrid-examples.blade.php">See demo code</a> <!-- TODO: link to demo code -->
+                            <a class="dropdown-item" target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/base-components#datagrid-1">See docs</a> <!-- TODO: link to final docs -->
                         </div>
                     </div>
                 </div>
@@ -65,8 +65,8 @@
                             </svg>
                         </a>
                         <div class="dropdown-menu dropdown-menu-end" style="">
-                            <a class="dropdown-item" href="#">See demo code</a> <!-- TODO: link to demo code -->
-                            <a class="dropdown-item" href="#">See docs</a> <!-- TODO: link to final docs -->
+                            <a class="dropdown-item" target="_blank" href="https://github.com/Laravel-Backpack/demo/blob/next/resources/views/admin/partials/datagrid-examples.blade.php">See demo code</a> <!-- TODO: link to demo code -->
+                            <a class="dropdown-item" target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/base-components#datagrid-1">See docs</a> <!-- TODO: link to final docs -->
                         </div>
                     </div>
                 </div>
@@ -112,8 +112,8 @@
                             </svg>
                         </a>
                         <div class="dropdown-menu dropdown-menu-end" style="">
-                            <a class="dropdown-item" href="#">See demo code</a> <!-- TODO: link to demo code -->
-                            <a class="dropdown-item" href="#">See docs</a> <!-- TODO: link to final docs -->
+                            <a class="dropdown-item" target="_blank" href="https://github.com/Laravel-Backpack/demo/blob/next/resources/views/admin/partials/datagrid-examples.blade.php">See demo code</a> <!-- TODO: link to demo code -->
+                            <a class="dropdown-item" target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/base-components#datagrid-1">See docs</a> <!-- TODO: link to final docs -->
                         </div>
                     </div>
                 </div>

--- a/resources/views/admin/partials/datalist-examples.blade.php
+++ b/resources/views/admin/partials/datalist-examples.blade.php
@@ -24,8 +24,8 @@
                             </svg>
                         </a>
                         <div class="dropdown-menu dropdown-menu-end" style="">
-                            <a class="dropdown-item" href="#">See demo code</a> <!-- TODO: link to demo code -->
-                            <a class="dropdown-item" href="#">See docs</a> <!-- TODO: link to final docs -->
+                            <a class="dropdown-item" target="_blank" href="https://github.com/Laravel-Backpack/demo/blob/next/resources/views/admin/partials/datalist-examples.blade.php">See demo code</a> <!-- TODO: link to demo code -->
+                            <a class="dropdown-item" target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/base-components#datalist-1">See docs</a> <!-- TODO: link to final docs -->
                         </div>
                     </div>
                 </div>
@@ -67,8 +67,8 @@
                             </svg>
                         </a>
                         <div class="dropdown-menu dropdown-menu-end" style="">
-                            <a class="dropdown-item" href="#">See demo code</a> <!-- TODO: link to demo code -->
-                            <a class="dropdown-item" href="#">See docs</a> <!-- TODO: link to final docs -->
+                            <a class="dropdown-item" target="_blank" href="https://github.com/Laravel-Backpack/demo/blob/next/resources/views/admin/partials/datalist-examples.blade.php">See demo code</a> <!-- TODO: link to demo code -->
+                            <a class="dropdown-item" target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/base-components#datalist-1">See docs</a> <!-- TODO: link to final docs -->
                         </div>
                     </div>
                 </div>
@@ -114,8 +114,8 @@
                             </svg>
                         </a>
                         <div class="dropdown-menu dropdown-menu-end" style="">
-                            <a class="dropdown-item" href="#">See demo code</a> <!-- TODO: link to demo code -->
-                            <a class="dropdown-item" href="#">See docs</a> <!-- TODO: link to final docs -->
+                            <a class="dropdown-item" target="_blank" href="https://github.com/Laravel-Backpack/demo/blob/next/resources/views/admin/partials/datalist-examples.blade.php">See demo code</a> <!-- TODO: link to demo code -->
+                            <a class="dropdown-item" target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/base-components#datalist-1">See docs</a> <!-- TODO: link to final docs -->
                         </div>
                     </div>
                 </div>

--- a/resources/views/admin/partials/datatable-examples.blade.php
+++ b/resources/views/admin/partials/datatable-examples.blade.php
@@ -19,8 +19,8 @@
                             </svg>
                         </a>
                         <div class="dropdown-menu dropdown-menu-end" style="">
-                            <a class="dropdown-item" href="#">See demo code</a> <!-- TODO: link to demo code -->
-                            <a class="dropdown-item" href="#">See docs</a> <!-- TODO: link to final docs -->
+                            <a class="dropdown-item" target="_blank" href="https://github.com/Laravel-Backpack/demo/blob/next/resources/views/admin/partials/datatable-examples.blade.php">See demo code</a> <!-- TODO: link to demo code -->
+                            <a class="dropdown-item" target="_blank" href="https://backpackforlaravel.com/docs/7.x-dev/base-components#datatable-1">See docs</a> <!-- TODO: link to final docs -->
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## WHY
<img width="249" height="82" alt="Screenshot 2025-07-13 at 9 54 36 PM" src="https://github.com/user-attachments/assets/ac5c7369-ac9f-4b20-ae8e-13b1774d6686" />

New component were not linked to docs at  https://bv7-demo.test/admin/new-in-v7 page.

## But Links Will Be Updated On Final Stable Release.

Yes after this PR, find and replace would make it quicker; **~7.x-dev~ 7.x**

