### PR TITLE
set maintenaince while refreshing the database

### DIFF
--- a/app/Console/Commands/RefreshDb.php
+++ b/app/Console/Commands/RefreshDb.php
@@ -39,10 +39,12 @@ class RefreshDb extends Command
      */
     public function handle()
     {
+        Artisan::call('down');
         Log::warning('Cleanup time. Refreshing the database.');
         Artisan::call('db:wipe --force');
         Artisan::call('migrate --force');
         Artisan::call('db:seed --force');
         Artisan::call('backup:clean');
+        Artisan::call('up');
     }
 }


### PR DESCRIPTION
As reported in https://github.com/Laravel-Backpack/community-forum/discussions/1372 

Sometimes we get weird errors while the database is beeing wiped every hour on demo. 

This ensures we set the app in maintenaince mode before wiping and seeding the database. 

