### PR TITLE
Make sqlite the default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,12 +6,12 @@ APP_URL=http://localhost
 BACKPACK_THEME=backpack.theme-tabler
 
 # MySQL Database Connection
-DB_CONNECTION=mysql
-DB_HOST=127.0.0.1
-DB_PORT=3306
-DB_DATABASE=homestead
-DB_USERNAME=homestead
-DB_PASSWORD=secret
+#DB_CONNECTION=mysql
+#DB_HOST=127.0.0.1
+#DB_PORT=3306
+#DB_DATABASE=homestead
+#DB_USERNAME=homestead
+#DB_PASSWORD=secret
 
 # PostgreSQL Database Connection
 #DB_CONNECTION=pgsql
@@ -22,9 +22,9 @@ DB_PASSWORD=secret
 #DB_PASSWORD=
 
 # SQLite Database Connection
-# You might also need to run 'touch storage/app/database.sqlite`  to create the db
-#DB_CONNECTION=sqlite
-#DB_DATABASE=../storage/app/database.sqlite
+# You might also need to run 'touch storage/app/database.sqlite`  to create the db if the file does not exist.
+DB_CONNECTION=sqlite
+DB_DATABASE=./storage/app/database.sqlite
 
 CACHE_DRIVER=file
 SESSION_DRIVER=file

--- a/database/seeders/PermissionManagerTablesSeeder.php
+++ b/database/seeders/PermissionManagerTablesSeeder.php
@@ -29,12 +29,12 @@ class PermissionManagerTablesSeeder extends Seeder
     ];
 
     /**
-     * Disable foreign key checks based on database driver
+     * Disable foreign key checks based on database driver.
      */
     protected function disableForeignKeyChecks()
     {
         $driver = DB::getDriverName();
-        
+
         switch ($driver) {
             case 'mysql':
                 DB::statement('SET FOREIGN_KEY_CHECKS=0;');
@@ -49,12 +49,12 @@ class PermissionManagerTablesSeeder extends Seeder
     }
 
     /**
-     * Enable foreign key checks based on database driver
+     * Enable foreign key checks based on database driver.
      */
     protected function enableForeignKeyChecks()
     {
         $driver = DB::getDriverName();
-        
+
         switch ($driver) {
             case 'mysql':
                 DB::statement('SET FOREIGN_KEY_CHECKS=1;');

--- a/database/seeders/PermissionManagerTablesSeeder.php
+++ b/database/seeders/PermissionManagerTablesSeeder.php
@@ -29,20 +29,60 @@ class PermissionManagerTablesSeeder extends Seeder
     ];
 
     /**
+     * Disable foreign key checks based on database driver
+     */
+    protected function disableForeignKeyChecks()
+    {
+        $driver = DB::getDriverName();
+        
+        switch ($driver) {
+            case 'mysql':
+                DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+                break;
+            case 'sqlite':
+                DB::statement('PRAGMA foreign_keys=OFF;');
+                break;
+            case 'pgsql':
+                // PostgreSQL doesn't have a global setting, would need to defer constraints
+                break;
+        }
+    }
+
+    /**
+     * Enable foreign key checks based on database driver
+     */
+    protected function enableForeignKeyChecks()
+    {
+        $driver = DB::getDriverName();
+        
+        switch ($driver) {
+            case 'mysql':
+                DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+                break;
+            case 'sqlite':
+                DB::statement('PRAGMA foreign_keys=ON;');
+                break;
+            case 'pgsql':
+                // PostgreSQL doesn't have a global setting, would need to defer constraints
+                break;
+        }
+    }
+
+    /**
      * Run the database seeds.
      *
      * @return void
      */
     public function run()
     {
-        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+        $this->disableForeignKeyChecks();
 
         DB::table(Config::get('permission.table_names.model_has_roles'))->truncate();
         DB::table(Config::get('permission.table_names.role_has_permissions'))->truncate();
         Permission::truncate();
         Role::truncate();
 
-        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+        $this->enableForeignKeyChecks();
 
         foreach ($this->roles as $role) {
             Role::create(['name' => $role, 'guard_name' => 'web']);


### PR DESCRIPTION
This makes sqlite the default db engine for the demo. 

removes friction to install by removing an additional dependency (mysql). 